### PR TITLE
Move `binding.js` to repository root

### DIFF
--- a/binding.js
+++ b/binding.js
@@ -1,0 +1,1 @@
+module.exports = require('node-gyp-build')(__dirname)

--- a/lib/binding.js
+++ b/lib/binding.js
@@ -1,4 +1,0 @@
-const path = require('path')
-const load = require('node-gyp-build')
-
-module.exports = load(path.join(__dirname, '..'))

--- a/lib/network-interfaces.js
+++ b/lib/network-interfaces.js
@@ -1,6 +1,6 @@
 const events = require('events')
 const b4a = require('b4a')
-const binding = require('./binding')
+const binding = require('../binding')
 
 module.exports = class NetworkInterfaces extends events.EventEmitter {
   constructor () {

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -1,6 +1,6 @@
 const events = require('events')
 const b4a = require('b4a')
-const binding = require('./binding')
+const binding = require('../binding')
 const ip = require('./ip')
 
 module.exports = class UDXSocket extends events.EventEmitter {

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,6 +1,6 @@
 const streamx = require('streamx')
 const b4a = require('b4a')
-const binding = require('./binding')
+const binding = require('../binding')
 const ip = require('./ip')
 
 const MAX_PACKET = 2048

--- a/lib/udx.js
+++ b/lib/udx.js
@@ -1,5 +1,5 @@
 const b4a = require('b4a')
-const binding = require('./binding')
+const binding = require('../binding')
 const ip = require('./ip')
 const Socket = require('./socket')
 const Stream = require('./stream')

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "src",
     "prebuilds",
     "binding.c",
-    "binding.gyp"
+    "binding.gyp",
+    "binding.js"
   ],
   "scripts": {
     "test": "standard && node test/all.js",


### PR DESCRIPTION
Removes the need for involving the `path` module.