### PR TITLE
Accept and forward `flags` in `udx_socket_bind()`

### DIFF
--- a/include/udx.h
+++ b/include/udx.h
@@ -332,7 +332,7 @@ int
 udx_socket_set_ttl (udx_socket_t *handle, int ttl);
 
 int
-udx_socket_bind (udx_socket_t *handle, const struct sockaddr *addr);
+udx_socket_bind (udx_socket_t *handle, const struct sockaddr *addr, unsigned int flags);
 
 int
 udx_socket_getsockname (udx_socket_t *handle, struct sockaddr *name, int *name_len);

--- a/src/udx.c
+++ b/src/udx.c
@@ -1352,7 +1352,7 @@ udx_socket_set_ttl (udx_socket_t *handle, int ttl) {
 }
 
 int
-udx_socket_bind (udx_socket_t *handle, const struct sockaddr *addr) {
+udx_socket_bind (udx_socket_t *handle, const struct sockaddr *addr, unsigned int flags) {
   uv_udp_t *socket = &(handle->socket);
   uv_poll_t *poll = &(handle->io_poll);
   uv_os_fd_t fd;
@@ -1366,7 +1366,7 @@ udx_socket_bind (udx_socket_t *handle, const struct sockaddr *addr) {
   }
 
   // This might actually fail in practice, so
-  int err = uv_udp_bind(socket, addr, 0);
+  int err = uv_udp_bind(socket, addr, flags);
   if (err) return err;
 
   // Asserting all the errors here as it massively simplifies error handling

--- a/test/socket-send-recv-dualstack.c
+++ b/test/socket-send-recv-dualstack.c
@@ -51,12 +51,12 @@ main () {
 
   struct sockaddr_in baddr;
   uv_ip4_addr("127.0.0.1", 8082, &baddr);
-  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr);
+  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr, 0);
   assert(e == 0);
 
   struct sockaddr_in6 aaddr;
   uv_ip6_addr("::", 8081, &aaddr);
-  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr);
+  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr, 0);
   assert(e == 0);
 
   udx_socket_recv_start(&asock, on_recv);

--- a/test/socket-send-recv-ipv6.c
+++ b/test/socket-send-recv-ipv6.c
@@ -51,12 +51,12 @@ main () {
 
   struct sockaddr_in6 baddr;
   uv_ip6_addr("::1", 8082, &baddr);
-  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr);
+  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr, 0);
   assert(e == 0);
 
   struct sockaddr_in6 aaddr;
   uv_ip6_addr("::1", 8081, &aaddr);
-  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr);
+  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr, 0);
   assert(e == 0);
 
   udx_socket_recv_start(&asock, on_recv);

--- a/test/socket-send-recv.c
+++ b/test/socket-send-recv.c
@@ -51,12 +51,12 @@ main () {
 
   struct sockaddr_in baddr;
   uv_ip4_addr("127.0.0.1", 8082, &baddr);
-  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr);
+  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr, 0);
   assert(e == 0);
 
   struct sockaddr_in aaddr;
   uv_ip4_addr("127.0.0.1", 8081, &aaddr);
-  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr);
+  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr, 0);
   assert(e == 0);
 
   udx_socket_recv_start(&asock, on_recv);

--- a/test/stream-destroy.c
+++ b/test/stream-destroy.c
@@ -32,7 +32,7 @@ main () {
 
   struct sockaddr_in addr;
   uv_ip4_addr("127.0.0.1", 8081, &addr);
-  e = udx_socket_bind(&sock, (struct sockaddr *) &addr);
+  e = udx_socket_bind(&sock, (struct sockaddr *) &addr, 0);
   assert(e == 0);
 
   udx_stream_t stream;

--- a/test/stream-preconnect-same-socket.c
+++ b/test/stream-preconnect-same-socket.c
@@ -53,7 +53,7 @@ main () {
   assert(e == 0);
 
   uv_ip4_addr("127.0.0.1", 8081, &addr);
-  e = udx_socket_bind(&sock, (struct sockaddr *) &addr);
+  e = udx_socket_bind(&sock, (struct sockaddr *) &addr, 0);
   assert(e == 0);
 
   e = udx_stream_init(&udx, &astream, 1, NULL);

--- a/test/stream-preconnect.c
+++ b/test/stream-preconnect.c
@@ -59,11 +59,11 @@ main () {
   assert(e == 0);
 
   uv_ip4_addr("127.0.0.1", 8081, &aaddr);
-  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr);
+  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr, 0);
   assert(e == 0);
 
   uv_ip4_addr("127.0.0.1", 8082, &baddr);
-  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr);
+  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr, 0);
   assert(e == 0);
 
   e = udx_stream_init(&udx, &astream, 1, NULL);

--- a/test/stream-relay.c
+++ b/test/stream-relay.c
@@ -70,19 +70,19 @@ main () {
   assert(e == 0);
 
   uv_ip4_addr("127.0.0.1", 8081, &aaddr);
-  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr);
+  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr, 0);
   assert(e == 0);
 
   uv_ip4_addr("127.0.0.1", 8082, &baddr);
-  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr);
+  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr, 0);
   assert(e == 0);
 
   uv_ip4_addr("127.0.0.1", 8083, &caddr);
-  e = udx_socket_bind(&csock, (struct sockaddr *) &caddr);
+  e = udx_socket_bind(&csock, (struct sockaddr *) &caddr, 0);
   assert(e == 0);
 
   uv_ip4_addr("127.0.0.1", 8084, &daddr);
-  e = udx_socket_bind(&dsock, (struct sockaddr *) &daddr);
+  e = udx_socket_bind(&dsock, (struct sockaddr *) &daddr, 0);
   assert(e == 0);
 
   e = udx_stream_init(&udx, &astream, 1, NULL);

--- a/test/stream-send-recv-ipv6.c
+++ b/test/stream-send-recv-ipv6.c
@@ -54,12 +54,12 @@ main () {
 
   struct sockaddr_in6 baddr;
   uv_ip6_addr("::1", 8082, &baddr);
-  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr);
+  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr, 0);
   assert(e == 0);
 
   struct sockaddr_in6 aaddr;
   uv_ip6_addr("::1", 8081, &aaddr);
-  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr);
+  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr, 0);
   assert(e == 0);
 
   e = udx_stream_init(&udx, &astream, 1, NULL);

--- a/test/stream-send-recv.c
+++ b/test/stream-send-recv.c
@@ -54,12 +54,12 @@ main () {
 
   struct sockaddr_in baddr;
   uv_ip4_addr("127.0.0.1", 8082, &baddr);
-  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr);
+  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr, 0);
   assert(e == 0);
 
   struct sockaddr_in aaddr;
   uv_ip4_addr("127.0.0.1", 8081, &aaddr);
-  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr);
+  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr, 0);
   assert(e == 0);
 
   e = udx_stream_init(&udx, &astream, 1, NULL);

--- a/test/stream-write-read-ipv6.c
+++ b/test/stream-write-read-ipv6.c
@@ -55,12 +55,12 @@ main () {
 
   struct sockaddr_in6 baddr;
   uv_ip6_addr("::1", 8082, &baddr);
-  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr);
+  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr, 0);
   assert(e == 0);
 
   struct sockaddr_in6 aaddr;
   uv_ip6_addr("::1", 8081, &aaddr);
-  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr);
+  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr, 0);
   assert(e == 0);
 
   e = udx_stream_init(&udx, &astream, 1, NULL);

--- a/test/stream-write-read.c
+++ b/test/stream-write-read.c
@@ -55,12 +55,12 @@ main () {
 
   struct sockaddr_in baddr;
   uv_ip4_addr("127.0.0.1", 8082, &baddr);
-  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr);
+  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr, 0);
   assert(e == 0);
 
   struct sockaddr_in aaddr;
   uv_ip4_addr("127.0.0.1", 8081, &aaddr);
-  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr);
+  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr, 0);
   assert(e == 0);
 
   e = udx_stream_init(&udx, &astream, 1, NULL);


### PR DESCRIPTION
This allow creating sockets that only bind to IPv6 by passing the `UV_UDP_IPV6ONLY` flag, for example.

We might want to introduce our own flags enum, I'm not sure. Currently, the flags are simply forwarded as-is to `uv_udp_bind()`.