### PR TITLE
Fix `udx_stream_write()` status code when drained

### DIFF
--- a/src/udx.c
+++ b/src/udx.c
@@ -661,7 +661,6 @@ get_window_bytes (udx_stream_t *stream) {
 
 static int
 fill_window (udx_stream_t *stream) {
-
   if (stream->pkts_waiting > 0) {
     int rc = flush_waiting_packets(stream);
     if (rc < 0) {
@@ -687,7 +686,6 @@ fill_window (udx_stream_t *stream) {
     if (buf->len < len) len = buf->len;
     if (mss < len) len = mss;
     if (mss > len && buf->len > len && stream->pkts_inflight > 0) {
-
       break;
     }
 
@@ -734,7 +732,7 @@ fill_window (udx_stream_t *stream) {
     }
   }
 
-  return 0;
+  return 1;
 }
 
 static int

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ list(APPEND tests
   stream-send-recv
   stream-send-recv-ipv6
   stream-write-read
+  stream-write-read-multiple
   stream-write-read-ipv6
   stream-write-read-perf
   stream-change-remote


### PR DESCRIPTION
If `udx_stream_write()` returns `0`, the contract is that the `on_drain` callback must be called when the write queue is flushed. Otherwise, it must return `1`.