### PR TITLE
Call `on_firewall` when receiving data on a different socket

### DIFF
--- a/src/udx.c
+++ b/src/udx.c
@@ -1186,7 +1186,7 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
   if (stream == NULL || stream->status & UDX_STREAM_DEAD) return 0;
 
   // We expect this to be a stream packet from now on
-  if (!(stream->status & UDX_STREAM_CONNECTED) && stream->on_firewall != NULL) {
+  if (stream->socket != socket && stream->on_firewall != NULL) {
     if (is_addr_v4_mapped((struct sockaddr *) addr)) {
       addr_to_v4((struct sockaddr_in6 *) addr);
     }


### PR DESCRIPTION
This will cause the `on_firewall` hook to fire whenever a stream receives data on a different socket than the one the stream is connected to, including the case where the stream is not yet connected to a socket. The primary use case relates to stream relaying where two streams start out connected through an external relay and then need to switch to a direct connection as soon as either side finds a viable socket.