### PR TITLE
zombie stream keeps libuv loop alive in some cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ target_sources(
     src/endian.c
     src/fifo.h
     src/fifo.c
+    src/queue.h
+    src/queue.c
     src/io.h
     src/udx.c
 )

--- a/include/udx.h
+++ b/include/udx.h
@@ -173,6 +173,12 @@ typedef struct udx_cong_s {
   uint32_t tcp_cwnd;
 } udx_cong_t;
 
+typedef struct {
+  uint32_t len;
+  udx_packet_t *prev;
+  udx_packet_t *next;
+} udx_queue_t;
+
 struct udx_stream_s {
   uint32_t local_id; // must be first entry, so its compat with the cirbuf
   uint32_t remote_id;
@@ -236,7 +242,6 @@ struct udx_stream_s {
   uint32_t rack_next_seq;
   uint32_t rack_fack;
 
-  uint32_t pkts_inflight; // packets inflight to the other peer
   uint32_t pkts_buffered; // how many (data) packets received but not processed (out of order)?
 
   // timestamps...
@@ -258,7 +263,8 @@ struct udx_stream_s {
   udx_cirbuf_t outgoing;
   udx_cirbuf_t incoming;
 
-  udx_fifo_t retransmit_queue; // udx_packet_t
+  udx_queue_t inflight_queue;
+  udx_queue_t retransmit_queue;
 
   udx_fifo_t unordered;
 };
@@ -266,7 +272,11 @@ struct udx_stream_s {
 struct udx_packet_s {
   uint32_t seq; // must be the first entry, so its compat with the cirbuf
 
-  int status;
+  udx_packet_t *prev;
+  udx_packet_t *next;
+
+  bool lost;
+
   int type;
   int ttl;
   int is_retransmit;

--- a/src/queue.c
+++ b/src/queue.c
@@ -1,0 +1,77 @@
+#include "../include/udx.h"
+#include "assert.h"
+#include "queue.h"
+
+void
+udx__queue_init (udx_queue_t *q) {
+  q->prev = (udx_packet_t *) q;
+  q->next = (udx_packet_t *) q;
+  q->len = 0;
+}
+
+// all insertion operations call this general version
+static void
+queue_insert (udx_packet_t *pkt, udx_packet_t *prev, udx_packet_t *next, udx_queue_t *queue) {
+  pkt->next = next;
+  pkt->prev = prev;
+  next->prev = pkt;
+  prev->next = pkt;
+
+  queue->len++;
+}
+
+static void
+queue_after (udx_queue_t *queue, udx_packet_t *prev, udx_packet_t *pkt) {
+  queue_insert(pkt, prev, prev->next, queue);
+}
+
+static void
+queue_before (udx_queue_t *queue, udx_packet_t *next, udx_packet_t *pkt) {
+  queue_insert(pkt, next->prev, next, queue);
+}
+
+void
+udx__queue_head (udx_queue_t *q, udx_packet_t *pkt) {
+  queue_after(q, (udx_packet_t *) q, pkt);
+}
+
+void
+udx__queue_tail (udx_queue_t *q, udx_packet_t *pkt) { // todo: queue_push
+  queue_before(q, (udx_packet_t *) q, pkt);
+}
+
+void
+udx__queue_unlink (udx_queue_t *q, udx_packet_t *pkt) {
+  assert(q->len != 0);
+  udx_packet_t *next;
+  udx_packet_t *prev;
+
+  q->len--;
+
+  next = pkt->next;
+  prev = pkt->prev;
+  pkt->next = NULL;
+  pkt->prev = NULL;
+
+  next->prev = prev;
+  prev->next = next;
+}
+
+udx_packet_t *
+udx__queue_peek (udx_queue_t *q) {
+  udx_packet_t *pkt = q->next;
+  if ((udx_queue_t *) pkt == q) {
+    pkt = NULL;
+  }
+  return pkt;
+}
+
+udx_packet_t *
+udx__queue_shift (udx_queue_t *q) { // udx__queue_dequeue
+  udx_packet_t *pkt = udx__queue_peek(q);
+
+  if (pkt) {
+    udx__queue_unlink(q, pkt);
+  }
+  return pkt;
+}

--- a/src/queue.h
+++ b/src/queue.h
@@ -1,0 +1,21 @@
+#ifndef UDX_QUEUE_H
+#define UDX_QUEUE_H
+
+#include "../include/udx.h"
+
+void
+udx__queue_init (udx_queue_t *q);
+void
+udx__queue_head (udx_queue_t *q, udx_packet_t *pkt); // unshift
+void
+udx__queue_tail (udx_queue_t *q, udx_packet_t *pkt); // push
+
+void
+udx__queue_unlink (udx_queue_t *q, udx_packet_t *pkt);
+
+udx_packet_t *
+udx__queue_peek (udx_queue_t *q);
+
+udx_packet_t *
+udx__queue_shift (udx_queue_t *q);
+#endif // UDX_QUEUE_H


### PR DESCRIPTION
fix use a circular linked list queue for stream in-flight and retransmit queues. the changes were cherry picked from the rack fix branch.

this should fix a bug where a stream is not ended and closed due to NULL's in the udx-fifo retransmit queue. The stream would be kept alive since it appears that the stream still has packets to retransmit, actually the packets were SACKed.