### PR TITLE
set timer for RACK reorder window and RTO instead of polling

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -30,6 +30,7 @@ debug_print_cwnd_stats (udx_stream_t *stream) {
     if (DEBUG) fprintf(stderr, __VA_ARGS__); \
   } while (0)
 
+/*
 static void
 debug_print_outgoing (udx_stream_t *stream) {
   if (DEBUG) {
@@ -40,18 +41,15 @@ debug_print_outgoing (udx_stream_t *stream) {
         continue;
       }
 
-      if (pkt->status == UDX_PACKET_STATE_INFLIGHT) {
-        debug_printf("I");
-        continue;
-      }
-      if (pkt->status == UDX_PACKET_STATE_RETRANSMIT) {
+      if (pkt->lost) {
         debug_printf("R");
-        continue;
+      } else {
+        debug_printf("I");
       }
-      assert(false && "should only be inflight or retransmitting");
     }
     debug_printf("\n");
   }
 }
+*/
 
 #endif // UDX_DEBUG_H


### PR DESCRIPTION
1. sets and clears timers for RACK and RTO, replacing the 20ms polling timer.
2. on RTO only retransmit the first segment and any segments outside rtt + reorder window. prevents extra retransmission of packets that have already been retransmitted by fast recovery. (per https://datatracker.ietf.org/doc/rfc8985/ 6.3)