### PR TITLE
add `on_finalize` callback

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -55,7 +55,7 @@ on_read (udx_stream_t *handle, ssize_t read_len, const uv_buf_t *buf) {
 
 static void
 on_send (udx_socket_send_t *r, int status) {
-  udx_stream_init(&udx, &stream, client_id, NULL);
+  udx_stream_init(&udx, &stream, client_id, NULL, NULL);
   udx_stream_connect(&stream, &sock, server_id, (struct sockaddr *) &dest_addr);
   udx_stream_read_start(&stream, on_read);
 }

--- a/examples/server.c
+++ b/examples/server.c
@@ -75,7 +75,7 @@ pump_stream () {
 
   printf("pumping %d bytes to stream to %s...\n", PUMP_BYTES, dst_ip);
 
-  udx_stream_init(&udx, &stream, server_id, on_close);
+  udx_stream_init(&udx, &stream, server_id, on_close, NULL);
   udx_stream_connect(&stream, &sock, client_id, (struct sockaddr *) &dest_addr);
 
   pump_writes();

--- a/examples/udxperf.c
+++ b/examples/udxperf.c
@@ -283,9 +283,11 @@ print_interval (udxperf_client_t *client, uint64_t bytes, uint64_t start, uint64
 
 static void
 server_on_destroy (udx_stream_t *stream, int status) {
-  udxperf_client_t *c = (udxperf_client_t *) stream;
   assert(status == 0);
+}
 
+static void
+server_on_finalize (udx_stream_t *stream) {
   free(stream);
   exit(0);
 }
@@ -342,7 +344,7 @@ server_handshake (udx_socket_t *sock, ssize_t read_len, const uv_buf_t *buf, con
 
   udx_stream_t *stream = &c->stream;
 
-  udx_stream_init(&udx, stream, server_id, server_on_destroy);
+  udx_stream_init(&udx, stream, server_id, server_on_destroy, server_on_finalize);
   udx_stream_connect(stream, sock, client_id, (struct sockaddr *) from);
 
   udx_stream_read_start(stream, server_on_read);
@@ -462,7 +464,7 @@ client_handshake_response (udx_socket_t *sock, ssize_t read_len, const uv_buf_t 
 
   assert(client_id == 1);
 
-  udx_stream_init(&udx, stream, client_id, NULL);
+  udx_stream_init(&udx, stream, client_id, NULL, NULL);
   udx_stream_connect(stream, sock, server_id, (struct sockaddr *) &raddr);
 
   assert(time_ms && "timer must be set");

--- a/include/udx.h
+++ b/include/udx.h
@@ -112,6 +112,7 @@ typedef void (*udx_stream_ack_cb)(udx_stream_write_t *req, int status, int unord
 typedef void (*udx_stream_send_cb)(udx_stream_send_t *req, int status);
 typedef void (*udx_stream_recv_cb)(udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf);
 typedef void (*udx_stream_close_cb)(udx_stream_t *stream, int status);
+typedef void (*udx_stream_finalize_cb)(udx_stream_t *stream);
 
 typedef void (*udx_lookup_cb)(udx_lookup_t *handle, int status, const struct sockaddr *addr, int addr_len);
 
@@ -223,6 +224,7 @@ struct udx_stream_s {
   udx_stream_recv_cb on_recv;
   udx_stream_drain_cb on_drain;
   udx_stream_close_cb on_close;
+  udx_stream_finalize_cb on_finalize;
 
   // mtu. RFC8899 5.1.1 and 5.1.3
   int mtu_state; // MTU_STATE_*
@@ -287,7 +289,6 @@ struct udx_stream_s {
 
   uint64_t packets_in;
   uint64_t packets_out;
-  int rc;
 };
 
 struct udx_packet_s {
@@ -441,7 +442,7 @@ int
 udx_check_timeouts (udx_t *udx);
 
 int
-udx_stream_init (udx_t *udx, udx_stream_t *stream, uint32_t local_id, udx_stream_close_cb close_cb);
+udx_stream_init (udx_t *udx, udx_stream_t *stream, uint32_t local_id, udx_stream_close_cb close_cb, udx_stream_finalize_cb finalize_cb);
 
 int
 udx_stream_get_mtu (udx_stream_t *stream, uint16_t *mtu);

--- a/test/stream-change-remote.c
+++ b/test/stream-change-remote.c
@@ -122,16 +122,16 @@ main () {
   e = udx_socket_bind(&dsock, (struct sockaddr *) &daddr, 0);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &astream, 1, NULL);
+  e = udx_stream_init(&udx, &astream, 1, NULL, NULL);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &bstream, 2, NULL);
+  e = udx_stream_init(&udx, &bstream, 2, NULL, NULL);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &cstream, 3, NULL);
+  e = udx_stream_init(&udx, &cstream, 3, NULL, NULL);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &dstream, 4, NULL);
+  e = udx_stream_init(&udx, &dstream, 4, NULL, NULL);
   assert(e == 0);
 
   // a <-> b  <-relay-> c <-> d

--- a/test/stream-destroy-before-connect.c
+++ b/test/stream-destroy-before-connect.c
@@ -14,7 +14,7 @@ main () {
   assert(e == 0);
 
   udx_stream_t stream;
-  e = udx_stream_init(&udx, &stream, 1, NULL);
+  e = udx_stream_init(&udx, &stream, 1, NULL, NULL);
   assert(e == 0);
 
   e = udx_stream_destroy(&stream);

--- a/test/stream-destroy.c
+++ b/test/stream-destroy.c
@@ -36,7 +36,7 @@ main () {
   assert(e == 0);
 
   udx_stream_t stream;
-  e = udx_stream_init(&udx, &stream, 1, on_close);
+  e = udx_stream_init(&udx, &stream, 1, on_close, NULL);
   assert(e == 0);
 
   e = udx_stream_connect(&stream, &sock, 2, (struct sockaddr *) &addr);

--- a/test/stream-multiple.c
+++ b/test/stream-multiple.c
@@ -87,13 +87,13 @@ main () {
     e = udx_socket_bind(&sender[i].usock, (struct sockaddr *) &sender[i].addr, 0);
     assert(e == 0);
     sender[i].write = malloc(udx_stream_write_sizeof(1));
-    e = udx_stream_init(&udx, &sender[i].stream, sender_id, NULL);
+    e = udx_stream_init(&udx, &sender[i].stream, sender_id, NULL, NULL);
 
     udx_socket_init(&udx, &receiver[i].usock);
     uv_ip4_addr("127.0.0.1", 8100 + i, &receiver[i].addr);
     e = udx_socket_bind(&receiver[i].usock, (struct sockaddr *) &receiver[i].addr, 0);
     assert(e == 0);
-    e = udx_stream_init(&udx, &receiver[i].stream, receiver_id, NULL);
+    e = udx_stream_init(&udx, &receiver[i].stream, receiver_id, NULL, NULL);
     assert(e == 0);
 
     e = udx_stream_read_start(&receiver[i].stream, on_read);

--- a/test/stream-preconnect-same-socket.c
+++ b/test/stream-preconnect-same-socket.c
@@ -58,10 +58,10 @@ main () {
   e = udx_socket_bind(&sock, (struct sockaddr *) &addr, 0);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &astream, 1, NULL);
+  e = udx_stream_init(&udx, &astream, 1, NULL, NULL);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &bstream, 2, NULL);
+  e = udx_stream_init(&udx, &bstream, 2, NULL, NULL);
   assert(e == 0);
 
   e = udx_stream_read_start(&astream, on_read);

--- a/test/stream-preconnect.c
+++ b/test/stream-preconnect.c
@@ -66,10 +66,10 @@ main () {
   e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr, 0);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &astream, 1, NULL);
+  e = udx_stream_init(&udx, &astream, 1, NULL, NULL);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &bstream, 2, NULL);
+  e = udx_stream_init(&udx, &bstream, 2, NULL, NULL);
   assert(e == 0);
 
   e = udx_stream_read_start(&astream, on_read);

--- a/test/stream-relay.c
+++ b/test/stream-relay.c
@@ -98,16 +98,16 @@ main () {
   e = udx_socket_bind(&dsock, (struct sockaddr *) &daddr, 0);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &astream, 1, NULL);
+  e = udx_stream_init(&udx, &astream, 1, NULL, NULL);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &bstream, 2, NULL);
+  e = udx_stream_init(&udx, &bstream, 2, NULL, NULL);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &cstream, 3, NULL);
+  e = udx_stream_init(&udx, &cstream, 3, NULL, NULL);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &dstream, 4, NULL);
+  e = udx_stream_init(&udx, &dstream, 4, NULL, NULL);
   assert(e == 0);
 
   e = udx_stream_relay_to(&cstream, &bstream);

--- a/test/stream-send-recv-ipv6.c
+++ b/test/stream-send-recv-ipv6.c
@@ -62,10 +62,10 @@ main () {
   e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr, 0);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &astream, 1, NULL);
+  e = udx_stream_init(&udx, &astream, 1, NULL, NULL);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &bstream, 2, NULL);
+  e = udx_stream_init(&udx, &bstream, 2, NULL, NULL);
   assert(e == 0);
 
   e = udx_stream_connect(&astream, &asock, 2, (struct sockaddr *) &baddr);

--- a/test/stream-send-recv.c
+++ b/test/stream-send-recv.c
@@ -62,10 +62,10 @@ main () {
   e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr, 0);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &astream, 1, NULL);
+  e = udx_stream_init(&udx, &astream, 1, NULL, NULL);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &bstream, 2, NULL);
+  e = udx_stream_init(&udx, &bstream, 2, NULL, NULL);
   assert(e == 0);
 
   e = udx_stream_connect(&astream, &asock, 2, (struct sockaddr *) &baddr);

--- a/test/stream-write-read-ipv6.c
+++ b/test/stream-write-read-ipv6.c
@@ -63,10 +63,10 @@ main () {
   e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr, 0);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &astream, 1, NULL);
+  e = udx_stream_init(&udx, &astream, 1, NULL, NULL);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &bstream, 2, NULL);
+  e = udx_stream_init(&udx, &bstream, 2, NULL, NULL);
   assert(e == 0);
 
   e = udx_stream_connect(&astream, &asock, 2, (struct sockaddr *) &baddr);

--- a/test/stream-write-read-multiple.c
+++ b/test/stream-write-read-multiple.c
@@ -62,10 +62,10 @@ main () {
   e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr, 0);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &astream, 1, NULL);
+  e = udx_stream_init(&udx, &astream, 1, NULL, NULL);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &bstream, 2, NULL);
+  e = udx_stream_init(&udx, &bstream, 2, NULL, NULL);
   assert(e == 0);
 
   e = udx_stream_connect(&astream, &asock, 2, (struct sockaddr *) &baddr);

--- a/test/stream-write-read-perf.c
+++ b/test/stream-write-read-perf.c
@@ -105,10 +105,10 @@ main () {
   e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr, 0);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &astream, 1, on_a_stream_close);
+  e = udx_stream_init(&udx, &astream, 1, on_a_stream_close, NULL);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &bstream, 2, on_b_stream_close);
+  e = udx_stream_init(&udx, &bstream, 2, on_b_stream_close, NULL);
   assert(e == 0);
 
   e = udx_stream_connect(&astream, &asock, 2, (struct sockaddr *) &baddr);

--- a/test/stream-write-read.c
+++ b/test/stream-write-read.c
@@ -65,10 +65,10 @@ main () {
   e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr, 0);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &astream, 1, NULL);
+  e = udx_stream_init(&udx, &astream, 1, NULL, NULL);
   assert(e == 0);
 
-  e = udx_stream_init(&udx, &bstream, 2, NULL);
+  e = udx_stream_init(&udx, &bstream, 2, NULL, NULL);
   assert(e == 0);
 
   e = udx_stream_connect(&astream, &asock, 2, (struct sockaddr *) &baddr);


### PR DESCRIPTION
adds an on_finalize callback to stream, which is fired after closing to notify the user that the memory backing stream may be freed