### PR TITLE
stream->inflight_queue and rack_detect_loss optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ target_sources(
     src/endian.c
     src/fifo.h
     src/fifo.c
+    src/queue.c
+    src/queue.h
     src/io.h
     src/udx.c
 )

--- a/examples/udxperf.c
+++ b/examples/udxperf.c
@@ -157,8 +157,7 @@ const char *kLabel_Byte[] =
     "MByte",
     "GByte",
     "TByte",
-    "PByte"
-};
+    "PByte"};
 
 /* labels for bit formats [kmg] */
 const char *kLabel_bit[] =
@@ -168,8 +167,7 @@ const char *kLabel_bit[] =
     "Mbit",
     "Gbit",
     "Tbit",
-    "Pbit"
-};
+    "Pbit"};
 
 /* -------------------------------------------------------------------
  * byte_snprintf
@@ -274,7 +272,7 @@ print_interval (udxperf_client_t *client, uint64_t bytes, uint64_t start, uint64
   byte_snprintf(bps_buf, sizeof bps_buf, bytes / time_sec, 'a');
   bps_buf[19] = '\0';
 
-  printf("[%3d] %6.4f-%6.4f sec %s %s/sec", stream->local_id, (start - client->start_time) / 1000.0, (end - client->start_time) / 1000.0, bytes_buf, bps_buf, stream->cwnd);
+  printf("[%3d] %6.4f-%6.4f sec %s %s/sec", stream->local_id, (start - client->start_time) / 1000.0, (end - client->start_time) / 1000.0, bytes_buf, bps_buf);
   if (is_client && extra_wanted) {
     printf(" cwnd=%d ssthresh=%d fast_recovery_count=%d rto_count=%d rtx_count=%d", stream->cwnd, stream->ssthresh, stream->fast_recovery_count, stream->rto_count, stream->retransmit_count);
   }

--- a/include/udx.h
+++ b/include/udx.h
@@ -261,7 +261,6 @@ struct udx_stream_s {
   uint32_t rack_next_seq;
   uint32_t rack_fack;
 
-  // uint32_t pkts_inflight; // packets inflight to the other peer. now inflight_queue.len
   uint32_t pkts_buffered; // how many (data) packets received but not processed (out of order)?
 
   // tlp

--- a/src/debug.h
+++ b/src/debug.h
@@ -9,6 +9,7 @@
 
 #ifdef DEBUG_STATS
 #include "../include/udx.h"
+#include "queue.h"
 #include <uv.h>
 
 static uint64_t debug_start = 0;
@@ -34,7 +35,7 @@ debug_print_cwnd_stats (udx_stream_t *stream) {
 static void
 debug_print_outgoing (udx_stream_t *stream) {
   if (DEBUG) {
-    for (uint32_t s = stream->remote_acked; s < stream->seq; s++) {
+    for (uint32_t s = stream->remote_acked; s != stream->seq; s++) {
       udx_packet_t *pkt = (udx_packet_t *) udx__cirbuf_get(&stream->outgoing, s);
       if (pkt == NULL) {
         debug_printf("-");
@@ -48,6 +49,30 @@ debug_print_outgoing (udx_stream_t *stream) {
       }
     }
     debug_printf("\n");
+
+    uint64_t now = uv_hrtime() / 1000000;
+    udx_queue_node_t *q;
+    if (stream->inflight_queue.len > 0) {
+      debug_printf("inflight q =");
+      udx__queue_foreach(q, &stream->inflight_queue.node) {
+        // for (udx_queue_node_t *q = stream->inflight_queue.node.next; q != &stream->inflight_queue.node; q = q->next) {
+        udx_packet_t *pkt = udx__queue_data(q, udx_packet_t, queue);
+        assert(!pkt->lost);
+        debug_printf("%u %lums ", pkt->seq, now - pkt->time_sent);
+      }
+      debug_printf("\n");
+    }
+
+    if (stream->retransmit_queue.len > 0) {
+
+      debug_printf("retransmit q =");
+      udx__queue_foreach(q, &stream->retransmit_queue.node) {
+        udx_packet_t *pkt = udx__queue_data(q, udx_packet_t, queue);
+        assert(pkt->lost);
+        debug_printf("%u %lums ", pkt->seq, now - pkt->time_sent);
+      }
+      debug_printf("\n");
+    }
   }
 }
 */

--- a/src/queue.c
+++ b/src/queue.c
@@ -1,0 +1,73 @@
+#include "../include/udx.h"
+#include "assert.h"
+#include "queue.h"
+
+void
+udx__queue_init (udx_queue_t *q) {
+
+  q->node.prev = &q->node;
+  q->node.next = &q->node;
+  q->len = 0;
+}
+
+// all insertion operations call this general version
+static void
+queue_insert (udx_queue_node_t *new, udx_queue_node_t *prev, udx_queue_node_t *next, udx_queue_t *queue) {
+  new->next = next;
+  new->prev = prev;
+  next->prev = new;
+  prev->next = new;
+
+  queue->len++;
+}
+
+static void
+queue_after (udx_queue_t *q, udx_queue_node_t *prev, udx_queue_node_t *new) {
+  queue_insert(new, prev, prev->next, q);
+}
+
+static void
+queue_before (udx_queue_t *q, udx_queue_node_t *next, udx_queue_node_t *new) {
+  queue_insert(new, next->prev, next, q);
+}
+
+void
+udx__queue_head (udx_queue_t *q, udx_queue_node_t *new) {
+  queue_after(q, (udx_queue_node_t *) q, new);
+}
+
+void
+udx__queue_tail (udx_queue_t *q, udx_queue_node_t *new) {
+  queue_before(q, (udx_queue_node_t *) q, new);
+}
+
+// assumes p must be a member of q
+void
+udx__queue_unlink (udx_queue_t *q, udx_queue_node_t *p) {
+  assert(q->len != 0);
+  q->len--;
+
+  p->prev->next = p->next;
+  p->next->prev = p->prev;
+  p->next = NULL;
+  p->prev = NULL;
+}
+
+udx_queue_node_t *
+udx__queue_peek (udx_queue_t *q) {
+  udx_queue_node_t *ret = q->node.next;
+  if (ret == &q->node) {
+    ret = NULL;
+  }
+  return ret;
+}
+
+udx_queue_node_t *
+udx__queue_shift (udx_queue_t *q) { // udx__queue_dequeue
+  udx_queue_node_t *ret = udx__queue_peek(q);
+
+  if (ret) {
+    udx__queue_unlink(q, ret);
+  }
+  return ret;
+}

--- a/src/queue.h
+++ b/src/queue.h
@@ -1,0 +1,27 @@
+#ifndef UDX_QUEUE_H
+#define UDX_QUEUE_H
+
+#include "../include/udx.h"
+
+#define udx__queue_data(pointer, type, field) \
+  ((type *) ((char *) (pointer) -offsetof(type, field)))
+
+#define udx__queue_foreach(q, h) \
+  for ((q) = (h)->next; (q) != (h); (q) = (q)->next)
+
+void
+udx__queue_init (udx_queue_t *q);
+void
+udx__queue_head (udx_queue_t *q, udx_queue_node_t *pkt); // unshift
+void
+udx__queue_tail (udx_queue_t *q, udx_queue_node_t *pkt); // push
+
+void
+udx__queue_unlink (udx_queue_t *q, udx_queue_node_t *pkt);
+
+udx_queue_node_t *
+udx__queue_peek (udx_queue_t *q);
+
+udx_queue_node_t *
+udx__queue_shift (udx_queue_t *q);
+#endif // UDX_QUEUE_H

--- a/src/udx.c
+++ b/src/udx.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <math.h>
+#include <stdalign.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -14,6 +15,7 @@
 #include "endian.h"
 #include "fifo.h"
 #include "io.h"
+#include "queue.h"
 
 #define UDX_STREAM_ALL_DESTROYED (UDX_STREAM_DESTROYED | UDX_STREAM_DESTROYED_REMOTE)
 #define UDX_STREAM_ALL_ENDED     (UDX_STREAM_ENDED | UDX_STREAM_ENDED_REMOTE)
@@ -201,7 +203,7 @@ stream_write_wanted (udx_stream_t *stream) {
     return true;
   }
 
-  return stream->pkts_inflight < stream->cwnd && ((stream->write_queue.len > 0) || stream->retransmit_queue.len > 0 || stream->unordered.len > 0);
+  return stream->inflight_queue.len < stream->cwnd && ((stream->write_queue.len > 0) || stream->retransmit_queue.len > 0 || stream->unordered.len > 0);
 }
 
 static bool
@@ -641,7 +643,6 @@ udx__shift_packet (udx_socket_t *socket) {
     size_t payload_len = 0;
 
     int ooo = stream->out_of_order;
-
     // 65536 is just a sanity check here in terms of how much max work we wanna do, could prob be smarter
     // only valid if ooo is very large
     for (uint32_t i = 0; i < 65536 && ooo > 0 && payload_len < 400; i++) {
@@ -710,20 +711,20 @@ udx__shift_packet (udx_socket_t *socket) {
     return pkt;
   }
 
-  if (!(stream->status & UDX_STREAM_DEAD) && stream->retransmit_queue.len > 0 && stream->pkts_inflight < stream->cwnd) {
+  if (!(stream->status & UDX_STREAM_DEAD) && stream->retransmit_queue.len > 0 && stream->inflight_queue.len < stream->cwnd) {
 
     while (stream->retransmit_queue.len > 0) {
-      udx_packet_t *pkt = udx__fifo_shift(&stream->retransmit_queue);
-      if (pkt == NULL) continue;
-      // pkt == 32?
-      stream->pkts_inflight++;
+      udx_packet_t *pkt = udx__queue_data(udx__queue_shift(&stream->retransmit_queue), udx_packet_t, queue);
+      assert(pkt != NULL);
+
+      udx__queue_tail(&stream->inflight_queue, &pkt->queue);
       stream->inflight += pkt->size;
 
       return pkt;
     }
   }
 
-  if (!(stream->status & UDX_STREAM_DEAD) && stream->write_queue.len > 0 && (stream->pkts_inflight < stream->cwnd || stream->write_wanted & UDX_STREAM_WRITE_WANT_TLP)) {
+  if (!(stream->status & UDX_STREAM_DEAD) && stream->write_queue.len > 0 && (stream->inflight_queue.len < stream->cwnd || stream->write_wanted & UDX_STREAM_WRITE_WANT_TLP)) {
 
     bool packet_will_be_tlp = stream->write_wanted & UDX_STREAM_WRITE_WANT_TLP;
 
@@ -802,8 +803,7 @@ udx__shift_packet (udx_socket_t *socket) {
       stream->mtu_probe_wanted = false;
     }
 
-    // undo if unshifted. needed to prevent creating more than cwnd packets
-    stream->pkts_inflight++;
+    udx__queue_tail(&stream->inflight_queue, &pkt->queue);
 
     assert(pkt->size > 0 && pkt->size < 1500);
     stream->inflight += pkt->size;
@@ -833,8 +833,10 @@ udx__shift_packet (udx_socket_t *socket) {
     }
     debug_printf("\n");
 
-    // packet may not actually be in the retransmit queue, but that's OK
-    udx__fifo_remove(&stream->retransmit_queue, pkt, pkt->fifo_gc);
+    if (pkt->lost) {
+      udx__queue_unlink(&stream->retransmit_queue, &pkt->queue);
+      udx__queue_tail(&stream->inflight_queue, &pkt->queue);
+    }
 
     stream->tlp_is_retrans = true;
     pkt->is_tlp = true;
@@ -905,7 +907,6 @@ close_maybe (udx_stream_t *stream, int err) {
   udx__cirbuf_destroy(&stream->outgoing);
   udx__fifo_destroy(&stream->unordered);
   udx__fifo_destroy(&stream->write_queue);
-  udx__fifo_destroy(&stream->retransmit_queue);
 
   uv_timer_stop(&stream->rto_timer);
   uv_timer_stop(&stream->rack_reo_timer);
@@ -1044,7 +1045,7 @@ udx__unshift_packet (udx_packet_t *pkt, udx_socket_t *socket) {
       stream->write_wanted |= UDX_STREAM_WRITE_WANT_TLP;
     }
 
-    stream->pkts_inflight--;
+    udx__queue_unlink(&stream->inflight_queue, &pkt->queue);
     stream->inflight -= pkt->size;
 
     // todo: optimize: put rollback writes onto the retransmit queue
@@ -1053,10 +1054,11 @@ udx__unshift_packet (udx_packet_t *pkt, udx_socket_t *socket) {
     // packet came from retransmit queue, return it.
     if (pkt->lost) {
       if (!pkt->is_tlp) {
-        udx__fifo_undo(&stream->retransmit_queue);
+        udx__queue_head(&stream->retransmit_queue, &pkt->queue);
       } else {
-        // a tlp packet is not necessarily from the start of the retransmit queue
-        pkt->fifo_gc = udx__fifo_push(&stream->retransmit_queue, pkt);
+        // tlp packets not necessarily from the head of the queue
+        // todo: iterate to find place in the queue?
+        udx__queue_tail(&stream->retransmit_queue, &pkt->queue);
       }
     } else {
       assert(pkt->transmits == 0);
@@ -1166,7 +1168,7 @@ schedule_loss_probe (udx_stream_t *stream) {
 
   if (stream->srtt) {
     pto = stream->srtt * 2;
-    if (stream->pkts_inflight == 1) {
+    if (stream->inflight_queue.len == 1) {
       pto += UDX_TLP_MAX_ACK_DELAY;
     }
   }
@@ -1187,38 +1189,43 @@ rack_detect_loss (udx_stream_t *stream) {
 
   int resending = 0;
   int mtu_probes_lost = 0;
+  udx_queue_node_t *p = NULL;
+  udx_queue_node_t *next = NULL; // save p->next so that we can remove it without breaking iteration
 
-  for (uint32_t seq = stream->remote_acked; seq != stream->seq; seq++) {
-    udx_packet_t *pkt = (udx_packet_t *) udx__cirbuf_get(&stream->outgoing, seq);
+  // can't use udx__queue_foreach because we may delete nodes in the middle
+  for (p = stream->inflight_queue.node.next, next = p->next;
+       p != &stream->inflight_queue.node;
+       p = next, next = p->next) {
 
-    if (pkt == NULL || pkt->lost) continue;
+    udx_packet_t *pkt = udx__queue_data(p, udx_packet_t, queue);
     assert(pkt->transmits > 0);
 
     // debug_printf("%lu > %lu=%d\n", stream->rack_time_sent, pkt->time_sent, stream->rack_time_sent > pkt->time_sent);
 
-    if (!rack_sent_after(stream->rack_time_sent, stream->rack_next_seq, pkt->time_sent, pkt->seq + 1)) {
-      continue;
-    }
+    if (rack_sent_after(stream->rack_time_sent, stream->rack_next_seq, pkt->time_sent, pkt->seq + 1)) {
 
-    int64_t remaining = pkt->time_sent + stream->rack_rtt + reo_wnd - now;
+      int64_t remaining = pkt->time_sent + stream->rack_rtt + reo_wnd - now;
 
-    if (remaining <= 0) {
-      pkt->lost = true;
+      if (remaining <= 0) {
+        pkt->lost = true;
 
-      assert(pkt->size > 0 && pkt->size < 1500);
-      stream->inflight -= pkt->size;
+        assert(pkt->size > 0 && pkt->size < 1500);
+        stream->inflight -= pkt->size;
 
-      stream->pkts_inflight--;
+        udx__queue_unlink(&stream->inflight_queue, &pkt->queue);
+        udx__queue_tail(&stream->retransmit_queue, &pkt->queue);
 
-      if (pkt->is_mtu_probe) {
-        mtu_unprobeify_packet(pkt, stream);
-        mtu_probes_lost++;
+        if (pkt->is_mtu_probe) {
+          mtu_unprobeify_packet(pkt, stream);
+          mtu_probes_lost++;
+        }
+
+        resending++;
+
+      } else if ((uint64_t) remaining > timeout) {
+        timeout = remaining;
+        break;
       }
-
-      resending++;
-      pkt->fifo_gc = udx__fifo_push(&stream->retransmit_queue, pkt);
-    } else if ((uint64_t) remaining > timeout) {
-      timeout = remaining;
     }
   }
 
@@ -1277,10 +1284,8 @@ udx_rto_timeout (uv_timer_t *timer) {
   assert(!(stream->status & UDX_STREAM_CLOSED));
   uv_timer_start(&stream->rto_timer, udx_rto_timeout, stream->rto * 2, 0);
 
-  // ensure that retransmit queue is in order
-  while (stream->retransmit_queue.len > 0) {
-    udx__fifo_shift(&stream->retransmit_queue);
-  }
+  // zero retransmit queue
+  udx__queue_init(&stream->retransmit_queue);
 
   debug_printf("rto: lost rid=%u [%u:%u] inflight=%lu ssthresh=%u cwnd=%u srtt=%u\n", stream->remote_id, stream->remote_acked, stream->seq, stream->inflight, stream->ssthresh, stream->cwnd, stream->srtt);
 
@@ -1289,13 +1294,13 @@ udx_rto_timeout (uv_timer_t *timer) {
 
   // rack 6.3
 
-  for (uint32_t seq = stream->remote_acked; seq < stream->seq; seq++) {
+  for (uint32_t seq = stream->remote_acked; seq != stream->seq; seq++) {
 
     udx_packet_t *pkt = (udx_packet_t *) udx__cirbuf_get(&stream->outgoing, seq);
     if (pkt == NULL) continue;
 
     if (pkt->lost) {
-      pkt->fifo_gc = udx__fifo_push(&stream->retransmit_queue, pkt);
+      udx__queue_tail(&stream->retransmit_queue, &pkt->queue);
       continue;
     }
 
@@ -1309,14 +1314,14 @@ udx_rto_timeout (uv_timer_t *timer) {
       }
 
       pkt->lost = true;
+      udx__queue_unlink(&stream->inflight_queue, &pkt->queue);
+      udx__queue_tail(&stream->retransmit_queue, &pkt->queue);
 
       stream->inflight -= pkt->size;
-      stream->pkts_inflight--;
 
       if (pkt->is_mtu_probe) {
         mtu_unprobeify_packet(pkt, stream);
       }
-      pkt->fifo_gc = udx__fifo_push(&stream->retransmit_queue, pkt);
     }
   }
 
@@ -1393,9 +1398,9 @@ ack_packet (udx_stream_t *stream, uint32_t seq, int sack) {
   }
 
   if (pkt->lost) {
-    udx__fifo_remove(&stream->retransmit_queue, pkt, pkt->fifo_gc);
+    udx__queue_unlink(&stream->retransmit_queue, &pkt->queue);
   } else {
-    stream->pkts_inflight--;
+    udx__queue_unlink(&stream->inflight_queue, &pkt->queue);
     stream->inflight -= pkt->size;
   }
 
@@ -1478,7 +1483,7 @@ ack_packet (udx_stream_t *stream, uint32_t seq, int sack) {
   // TODO: the end condition needs work here to be more "stateless"
   // ie if the remote has acked all our writes, then instead of waiting for retransmits, we should
   // clear those and mark as local ended NOW.
-  if ((stream->status & UDX_STREAM_SHOULD_END) == UDX_STREAM_END && stream->pkts_inflight == 0 && stream->retransmit_queue.len == 0 && stream->write_queue.len == 0) {
+  if ((stream->status & UDX_STREAM_SHOULD_END) == UDX_STREAM_END && stream->inflight_queue.len == 0 && stream->retransmit_queue.len == 0 && stream->write_queue.len == 0) {
     stream->status |= UDX_STREAM_ENDED;
     return 2;
   }
@@ -1510,14 +1515,9 @@ process_sacks (udx_stream_t *stream, char *buf, size_t buf_len) {
 
 static void
 process_data_packet (udx_stream_t *stream, int type, uint32_t seq, char *data, ssize_t data_len) {
-  if (seq == stream->ack && type == UDX_HEADER_DATA) {
+  if (seq == stream->ack && type & UDX_HEADER_DATA) {
     // Fast path - next in line, no need to memcpy it, stack allocate the struct and call on_read...
     stream->ack++;
-
-    stream->write_wanted |= UDX_STREAM_WRITE_WANT_STATE;
-    if (stream->socket != NULL) {
-      update_poll(stream->socket);
-    }
 
     if (stream->on_read != NULL) {
       uv_buf_t buf = uv_buf_init(data, data_len);
@@ -1785,7 +1785,7 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
   if (delivered > 0) {
 
     if (stream->remote_acked == stream->seq) {
-      assert(stream->pkts_inflight == 0 && stream->retransmit_queue.len == 0);
+      assert(stream->inflight_queue.len == 0 && stream->retransmit_queue.len == 0);
       uv_timer_stop(&stream->rto_timer);
       uv_timer_stop(&stream->tlp_timer);
     } else {
@@ -2210,7 +2210,9 @@ udx_stream_init (udx_t *udx, udx_stream_t *stream, uint32_t local_id, udx_stream
   stream->nrefs = 3;
   stream->deferred_ack = 0;
 
-  stream->pkts_inflight = 0;
+  udx__queue_init(&stream->inflight_queue);
+  udx__queue_init(&stream->retransmit_queue);
+
   stream->pkts_buffered = 0;
 
   stream->sacks = 0;
@@ -2243,7 +2245,9 @@ udx_stream_init (udx_t *udx, udx_stream_t *stream, uint32_t local_id, udx_stream
   udx__fifo_init(&(stream->unordered), 1);
 
   udx__fifo_init(&stream->write_queue, 1);
-  udx__fifo_init(&stream->retransmit_queue, 1);
+
+  udx__queue_init(&stream->inflight_queue);
+  udx__queue_init(&stream->retransmit_queue);
 
   stream->set_id = udx->streams_len++;
 

--- a/src/udx.c
+++ b/src/udx.c
@@ -1202,6 +1202,10 @@ rack_detect_loss (udx_stream_t *stream) {
 
     // debug_printf("%lu > %lu=%d\n", stream->rack_time_sent, pkt->time_sent, stream->rack_time_sent > pkt->time_sent);
 
+    if (pkt->time_sent > stream->rack_time_sent) {
+      break;
+    }
+
     if (rack_sent_after(stream->rack_time_sent, stream->rack_next_seq, pkt->time_sent, pkt->seq + 1)) {
 
       int64_t remaining = pkt->time_sent + stream->rack_rtt + reo_wnd - now;
@@ -1224,7 +1228,6 @@ rack_detect_loss (udx_stream_t *stream) {
 
       } else if ((uint64_t) remaining > timeout) {
         timeout = remaining;
-        break;
       }
     }
   }


### PR DESCRIPTION
Adds a circularly linked queue to the stream and packet objects, allowing tracking an 'inflight_queue' where packets are ordered by pkt->time_sent. this enables an early return in rack_detect_loss suggested in RFC8985:

>As an optimization, an implementation can choose to check only
>    segments that have been sent before RACK.xmit_ts.  This can be more
>    efficient than scanning the entire SACK scoreboard, especially when
>    there are many segments in flight.  The implementation can use a
>    separate doubly linked list ordered by Segment.xmit_ts, insert a
>    segment at the tail of the list when it is (re)transmitted, and
>    remove a segment from the list when it is delivered or marked as
>    lost.  In Linux TCP, this optimization improved CPU usage by orders
>    of magnitude during some fast recovery episodes on high-speed WAN
>    networks.

also fixes two bugs, 1) in udx_rto_timeout `seq < stream->seq` was used where `seq != stream->seq` should be, which would cause less than the full flight to be retransmitted if an RTO occurred during a sequence wrap and 2) in-order DATA|END combined packets would be queued as out-of-order because the code checked type == DATA  instead of type & DATA. They would then be processed immediately so there was no consequence.