### PR TITLE
tlp not sent when it should retransmit already sent data

### DIFF
--- a/src/udx.c
+++ b/src/udx.c
@@ -621,231 +621,230 @@ udx__shift_packet (udx_socket_t *socket) {
     return pkt;
   }
 
-  udx_stream_t *stream = get_stream(socket);
+  udx_stream_t *stream;
 
-  if (stream == NULL) {
-    return NULL;
-  }
+  while ((stream = get_stream(socket)) != NULL) {
 
-  if (stream->unordered.len > 0) {
-    udx_packet_t *pkt = udx__fifo_shift(&stream->unordered);
-    assert(pkt != NULL);
-    return pkt;
-  }
+    if (stream->unordered.len > 0) {
+      udx_packet_t *pkt = udx__fifo_shift(&stream->unordered);
+      assert(pkt != NULL);
+      return pkt;
+    }
 
-  if (stream->write_wanted & UDX_STREAM_WRITE_WANT_STATE) {
+    if (stream->write_wanted & UDX_STREAM_WRITE_WANT_STATE) {
 
-    assert(stream->status & UDX_STREAM_CONNECTED);
+      assert(stream->status & UDX_STREAM_CONNECTED);
 
-    uint32_t *sacks = NULL;
-    uint32_t start = 0;
-    uint32_t end = 0;
+      uint32_t *sacks = NULL;
+      uint32_t start = 0;
+      uint32_t end = 0;
 
-    udx_packet_t *pkt = NULL;
+      udx_packet_t *pkt = NULL;
 
-    void *payload = NULL;
-    size_t payload_len = 0;
+      void *payload = NULL;
+      size_t payload_len = 0;
 
-    int ooo = stream->out_of_order;
+      int ooo = stream->out_of_order;
 
-    // 65536 is just a sanity check here in terms of how much max work we wanna do, could prob be smarter
-    // only valid if ooo is very large
-    for (uint32_t i = 0; i < 65536 && ooo > 0 && payload_len < 400; i++) {
-      uint32_t seq = stream->ack + 1 + i;
-      if (udx__cirbuf_get(&(stream->incoming), seq) == NULL) continue;
+      // 65536 is just a sanity check here in terms of how much max work we wanna do, could prob be smarter
+      // only valid if ooo is very large
+      for (uint32_t i = 0; i < 65536 && ooo > 0 && payload_len < 400; i++) {
+        uint32_t seq = stream->ack + 1 + i;
+        if (udx__cirbuf_get(&(stream->incoming), seq) == NULL) continue;
 
-      ooo--;
+        ooo--;
 
-      if (sacks == NULL) {
-        pkt = malloc(sizeof(udx_packet_t) + sizeof(uv_buf_t) * 3 + 1024);
-        payload = (((char *) pkt) + sizeof(udx_packet_t) + 3 * sizeof(uv_buf_t));
-        sacks = (uint32_t *) payload;
-        start = seq;
-        end = seq + 1;
-      } else if (seq == end) {
-        end++;
-      } else {
+        if (sacks == NULL) {
+          pkt = malloc(sizeof(udx_packet_t) + sizeof(uv_buf_t) * 3 + 1024);
+          payload = (((char *) pkt) + sizeof(udx_packet_t) + 3 * sizeof(uv_buf_t));
+          sacks = (uint32_t *) payload;
+          start = seq;
+          end = seq + 1;
+        } else if (seq == end) {
+          end++;
+        } else {
+          *(sacks++) = udx__swap_uint32_if_be(start);
+          *(sacks++) = udx__swap_uint32_if_be(end);
+          start = seq;
+          end = seq + 1;
+          payload_len += 8;
+        }
+      }
+
+      if (start != end) {
         *(sacks++) = udx__swap_uint32_if_be(start);
         *(sacks++) = udx__swap_uint32_if_be(end);
-        start = seq;
-        end = seq + 1;
         payload_len += 8;
       }
-    }
 
-    if (start != end) {
-      *(sacks++) = udx__swap_uint32_if_be(start);
-      *(sacks++) = udx__swap_uint32_if_be(end);
-      payload_len += 8;
-    }
+      if (pkt == NULL) pkt = malloc(sizeof(udx_packet_t) + sizeof(uv_buf_t) * 3);
 
-    if (pkt == NULL) pkt = malloc(sizeof(udx_packet_t) + sizeof(uv_buf_t) * 3);
+      uv_buf_t buf = uv_buf_init(payload, payload_len);
 
-    uv_buf_t buf = uv_buf_init(payload, payload_len);
+      // debug_printf("state packet: id dst=%u seq=%u ack=%u\n", stream->remote_id, stream->seq, stream->ack);
+      init_stream_packet(pkt, payload ? UDX_HEADER_SACK : 0, stream, &buf, 1);
 
-    // debug_printf("state packet: id dst=%u seq=%u ack=%u\n", stream->remote_id, stream->seq, stream->ack);
-    init_stream_packet(pkt, payload ? UDX_HEADER_SACK : 0, stream, &buf, 1);
+      pkt->type = UDX_PACKET_TYPE_STREAM_STATE;
+      pkt->ctx = stream;
+      pkt->ttl = 0;
 
-    pkt->type = UDX_PACKET_TYPE_STREAM_STATE;
-    pkt->ctx = stream;
-    pkt->ttl = 0;
-
-    // must clear it here so that we can send a non-state packet
-    stream->write_wanted &= ~UDX_STREAM_WRITE_WANT_STATE;
-
-    return pkt;
-  }
-
-  if (stream->write_wanted & UDX_STREAM_WRITE_WANT_DESTROY) {
-    // todo: pass in pointer to stack to write to instead of malloc
-    // for 'free-on-send' packets
-
-    udx_packet_t *pkt = malloc(sizeof(udx_packet_t) + 2 * sizeof(uv_buf_t));
-
-    uv_buf_t buf = uv_buf_init(NULL, 0);
-
-    init_stream_packet(pkt, UDX_HEADER_DESTROY, stream, &buf, 0);
-
-    pkt->type = UDX_PACKET_TYPE_STREAM_DESTROY;
-    pkt->ttl = 0;
-    pkt->ctx = stream;
-
-    stream->seq++;
-
-    stream->write_wanted &= ~UDX_STREAM_WRITE_WANT_DESTROY;
-    return pkt;
-  }
-
-  if (!(stream->status & UDX_STREAM_DEAD) && stream->retransmit_queue.len > 0 && stream->pkts_inflight < stream->cwnd) {
-
-    while (stream->retransmit_queue.len > 0) {
-      udx_packet_t *pkt = udx__fifo_shift(&stream->retransmit_queue);
-      if (pkt == NULL) continue;
-      // pkt == 32?
-      stream->pkts_inflight++;
-      stream->inflight += pkt->size;
+      // must clear it here so that we can send a non-state packet
+      stream->write_wanted &= ~UDX_STREAM_WRITE_WANT_STATE;
 
       return pkt;
     }
-  }
 
-  if (!(stream->status & UDX_STREAM_DEAD) && stream->write_queue.len > 0 && (stream->pkts_inflight < stream->cwnd || stream->write_wanted & UDX_STREAM_WRITE_WANT_TLP)) {
+    if (stream->write_wanted & UDX_STREAM_WRITE_WANT_DESTROY) {
+      // todo: pass in pointer to stack to write to instead of malloc
+      // for 'free-on-send' packets
 
-    bool packet_will_be_tlp = stream->write_wanted & UDX_STREAM_WRITE_WANT_TLP;
+      udx_packet_t *pkt = malloc(sizeof(udx_packet_t) + 2 * sizeof(uv_buf_t));
 
-    // header_flag will be either
-    // DATA     - packet has payload and all data written with udx_stream_write()
-    // DATA|END - packet has payload and and some or all data was written with udx_stream_write_end()
-    // END      - packet has no payload and is the result of udx_stream_write_end() with an empty buffer
+      uv_buf_t buf = uv_buf_init(NULL, 0);
 
-    int header_flag = 0;
+      init_stream_packet(pkt, UDX_HEADER_DESTROY, stream, &buf, 0);
 
-    uint32_t mss = max_payload(stream);
+      pkt->type = UDX_PACKET_TYPE_STREAM_DESTROY;
+      pkt->ttl = 0;
+      pkt->ctx = stream;
 
-    uint64_t capacity = mss;
+      stream->seq++;
 
-    uv_buf_t bufs[UDX_MAX_COMBINED_WRITES];
-    udx_stream_write_buf_t *wbufs[UDX_MAX_COMBINED_WRITES];
+      stream->write_wanted &= ~UDX_STREAM_WRITE_WANT_DESTROY;
+      return pkt;
+    }
 
-    int nwbufs = 0;
-    size_t size = 0;
+    if (!(stream->status & UDX_STREAM_DEAD) && stream->retransmit_queue.len > 0 && stream->pkts_inflight < stream->cwnd) {
 
-    while (capacity > 0 && nwbufs < UDX_MAX_COMBINED_WRITES && stream->write_queue.len > 0) {
-      udx_stream_write_buf_t *wbuf = udx__fifo_peek(&stream->write_queue);
+      while (stream->retransmit_queue.len > 0) {
+        udx_packet_t *pkt = udx__fifo_shift(&stream->retransmit_queue);
+        if (pkt == NULL) continue;
+        // pkt == 32?
+        stream->pkts_inflight++;
+        stream->inflight += pkt->size;
 
-      uv_buf_t *buf = &wbuf->buf;
-
-      uint64_t writesz = buf->len - wbuf->bytes_acked - wbuf->bytes_inflight;
-
-      size_t len = min_uint64(capacity, writesz);
-      // printf("len=%lu capacity=%lu writesz=%lu\n", len, capacity, writesz);
-
-      uv_buf_t partial = uv_buf_init(buf->base + wbuf->bytes_acked + wbuf->bytes_inflight, len);
-      wbuf->bytes_inflight += len;
-      capacity -= len;
-
-      bufs[nwbufs] = partial;
-      wbufs[nwbufs] = wbuf;
-
-      size += len;
-      nwbufs++;
-
-      if (size > 0) {
-        header_flag |= UDX_HEADER_DATA;
+        return pkt;
       }
+    }
 
-      if ((wbuf->bytes_acked + wbuf->bytes_inflight) == wbuf->buf.len) {
-        if (wbuf->is_write_end) {
-          header_flag |= UDX_HEADER_END;
+    if (!(stream->status & UDX_STREAM_DEAD) && stream->write_queue.len > 0 && (stream->pkts_inflight < stream->cwnd || stream->write_wanted & UDX_STREAM_WRITE_WANT_TLP)) {
+
+      bool packet_will_be_tlp = stream->write_wanted & UDX_STREAM_WRITE_WANT_TLP;
+
+      // header_flag will be either
+      // DATA     - packet has payload and all data written with udx_stream_write()
+      // DATA|END - packet has payload and and some or all data was written with udx_stream_write_end()
+      // END      - packet has no payload and is the result of udx_stream_write_end() with an empty buffer
+
+      int header_flag = 0;
+
+      uint32_t mss = max_payload(stream);
+
+      uint64_t capacity = mss;
+
+      uv_buf_t bufs[UDX_MAX_COMBINED_WRITES];
+      udx_stream_write_buf_t *wbufs[UDX_MAX_COMBINED_WRITES];
+
+      int nwbufs = 0;
+      size_t size = 0;
+
+      while (capacity > 0 && nwbufs < UDX_MAX_COMBINED_WRITES && stream->write_queue.len > 0) {
+        udx_stream_write_buf_t *wbuf = udx__fifo_peek(&stream->write_queue);
+
+        uv_buf_t *buf = &wbuf->buf;
+
+        uint64_t writesz = buf->len - wbuf->bytes_acked - wbuf->bytes_inflight;
+
+        size_t len = min_uint64(capacity, writesz);
+        // printf("len=%lu capacity=%lu writesz=%lu\n", len, capacity, writesz);
+
+        uv_buf_t partial = uv_buf_init(buf->base + wbuf->bytes_acked + wbuf->bytes_inflight, len);
+        wbuf->bytes_inflight += len;
+        capacity -= len;
+
+        bufs[nwbufs] = partial;
+        wbufs[nwbufs] = wbuf;
+
+        size += len;
+        nwbufs++;
+
+        if (size > 0) {
+          header_flag |= UDX_HEADER_DATA;
         }
-        udx__fifo_shift(&stream->write_queue);
+
+        if ((wbuf->bytes_acked + wbuf->bytes_inflight) == wbuf->buf.len) {
+          if (wbuf->is_write_end) {
+            header_flag |= UDX_HEADER_END;
+          }
+          udx__fifo_shift(&stream->write_queue);
+        }
       }
+
+      assert(header_flag & UDX_HEADER_DATA_OR_END);
+
+      int nbufs = 2 + nwbufs; // extra for 1.header 2.padding
+
+      udx_packet_t *pkt = malloc(sizeof(udx_packet_t) + sizeof(uv_buf_t) * nbufs + sizeof(void *) * nwbufs);
+
+      init_stream_packet(pkt, header_flag, stream, bufs, nwbufs);
+      pkt->wbufs = (udx_stream_write_buf_t **) (((uv_buf_t *) (pkt + 1)) + nbufs);
+      pkt->nwbufs = nwbufs;
+
+      for (int i = 0; i < nwbufs; i++) {
+        pkt->wbufs[i] = wbufs[i];
+      }
+
+      pkt->ctx = stream;
+      pkt->type = UDX_PACKET_TYPE_STREAM_WRITE;
+      pkt->ttl = 0;
+
+      // decrement if packet is unshifted - or move to confirm packet
+      stream->seq++;
+
+      if (stream->mtu_probe_wanted && mtu_probeify_packet(pkt, stream->mtu_probe_size)) {
+        stream->mtu_probe_count++;
+        stream->mtu_probe_wanted = false;
+      }
+
+      // undo if unshifted. needed to prevent creating more than cwnd packets
+      stream->pkts_inflight++;
+
+      assert(pkt->size > 0 && pkt->size < 1500);
+      stream->inflight += pkt->size;
+
+      if (packet_will_be_tlp) {
+        stream->write_wanted &= ~UDX_STREAM_WRITE_WANT_TLP;
+        stream->tlp_is_retrans = false;
+        pkt->is_tlp = true;
+      }
+
+      return pkt;
     }
 
-    assert(header_flag & UDX_HEADER_DATA_OR_END);
+    // if we don't have a new packet to send to satisfy TLP, re-transmit an old one
 
-    int nbufs = 2 + nwbufs; // extra for 1.header 2.padding
-
-    udx_packet_t *pkt = malloc(sizeof(udx_packet_t) + sizeof(uv_buf_t) * nbufs + sizeof(void *) * nwbufs);
-
-    init_stream_packet(pkt, header_flag, stream, bufs, nwbufs);
-    pkt->wbufs = (udx_stream_write_buf_t **) (((uv_buf_t *) (pkt + 1)) + nbufs);
-    pkt->nwbufs = nwbufs;
-
-    for (int i = 0; i < nwbufs; i++) {
-      pkt->wbufs[i] = wbufs[i];
-    }
-
-    pkt->ctx = stream;
-    pkt->type = UDX_PACKET_TYPE_STREAM_WRITE;
-    pkt->ttl = 0;
-
-    // decrement if packet is unshifted - or move to confirm packet
-    stream->seq++;
-
-    if (stream->mtu_probe_wanted && mtu_probeify_packet(pkt, stream->mtu_probe_size)) {
-      stream->mtu_probe_count++;
-      stream->mtu_probe_wanted = false;
-    }
-
-    // undo if unshifted. needed to prevent creating more than cwnd packets
-    stream->pkts_inflight++;
-
-    assert(pkt->size > 0 && pkt->size < 1500);
-    stream->inflight += pkt->size;
-
-    if (packet_will_be_tlp) {
+    if (stream->write_wanted & UDX_STREAM_WRITE_WANT_TLP && stream->write_queue.len == 0) {
+      // rack 7.3
       stream->write_wanted &= ~UDX_STREAM_WRITE_WANT_TLP;
-      stream->tlp_is_retrans = false;
+
+      udx_packet_t *pkt = (udx_packet_t *) udx__cirbuf_get(&stream->outgoing, stream->seq - 1);
+
+      debug_printf("tlp: retransmitting old data");
+
+      if (!pkt) {
+        debug_printf("... not available\n");
+        continue;
+      }
+      debug_printf("\n");
+
+      // packet may not actually be in the retransmit queue, but that's OK
+      udx__fifo_remove(&stream->retransmit_queue, pkt, pkt->fifo_gc);
+
+      stream->tlp_is_retrans = true;
       pkt->is_tlp = true;
+      return pkt;
     }
-
-    return pkt;
   }
-
-  // if we don't have a new packet to send to satisfy TLP, re-transmit an old one
-
-  if (stream->write_wanted & UDX_STREAM_WRITE_WANT_TLP && stream->write_queue.len == 0) {
-    // rack 7.3
-    stream->write_wanted &= ~UDX_STREAM_WRITE_WANT_TLP;
-
-    udx_packet_t *pkt = (udx_packet_t *) udx__cirbuf_get(&stream->outgoing, stream->seq - 1);
-
-    debug_printf("tlp: retransmitting old data");
-
-    if (!pkt) {
-      debug_printf("... not available\n");
-      return NULL;
-    }
-    debug_printf("\n");
-
-    // packet may not actually be in the retransmit queue, but that's OK
-    udx__fifo_remove(&stream->retransmit_queue, pkt, pkt->fifo_gc);
-
-    stream->tlp_is_retrans = true;
-    pkt->is_tlp = true;
-  }
-
   return NULL;
 }
 


### PR DESCRIPTION
when sending a TLP there are two cases
1. new data is available to send (common case). A packet is created with this new data to solicit a SACK indicating tail loss
2. no new data is available, try retransmitting the last packet to solicit a SACK

The bug is in case 2, we don't actually transmit the packet (see note below)

instead of returning NULL if the TLP can't be sent we loop and try and produce another packet type.