### PR TITLE
add bytes-inflight in case of retransmit-TLP

### DIFF
--- a/src/udx.c
+++ b/src/udx.c
@@ -842,8 +842,15 @@ udx__shift_packet (udx_socket_t *socket) {
       }
       debug_printf("\n");
 
-      // packet may not actually be in the retransmit queue, but that's OK
-      udx__fifo_remove(&stream->retransmit_queue, pkt, pkt->fifo_gc);
+      // we selected the packet with the highest sequence number to retransmit
+      // it may be in-flight already or it may be marked 'lost' (in the retransmit queue)
+      // if not inflight already, mark it inflight and adjust counters:
+
+      if (pkt->lost) {
+        udx__fifo_remove(&stream->retransmit_queue, pkt, pkt->fifo_gc);
+        stream->inflight += pkt->size;
+        stream->pkts_inflight++;
+      }
 
       stream->tlp_is_retrans = true;
       pkt->is_tlp = true;


### PR DESCRIPTION
stream->inflight and stream->pkts_inflight weren't incremented when a TLP is created from data in the retransmit_queue.