### PR TITLE
add a stat for packets dropped from socket receive buffer

### DIFF
--- a/include/udx.h
+++ b/include/udx.h
@@ -159,7 +159,7 @@ struct udx_socket_s {
   uint64_t packets_rx;
   uint64_t packets_tx;
 
-  int64_t npackets_dropped_since_last_recv;
+  int64_t packets_dropped_by_kernel;
 };
 
 typedef struct udx_cong_s {

--- a/include/udx.h
+++ b/include/udx.h
@@ -140,6 +140,7 @@ struct udx_socket_s {
   udx_t *udx;
   udx_cirbuf_t *streams_by_id; // for convenience
 
+  bool cmsg_wanted; // include a control buffer for recvmsg
   int family;
   int status;
   int readers;
@@ -157,6 +158,8 @@ struct udx_socket_s {
 
   uint64_t packets_rx;
   uint64_t packets_tx;
+
+  int64_t npackets_dropped_since_last_recv;
 };
 
 typedef struct udx_cong_s {

--- a/src/io.h
+++ b/src/io.h
@@ -12,4 +12,7 @@ udx__sendmsg (udx_socket_t *handle, const uv_buf_t bufs[], unsigned int bufs_len
 ssize_t
 udx__recvmsg (udx_socket_t *handle, uv_buf_t *buf, struct sockaddr *addr, int addr_len);
 
+int
+udx__udp_set_rxq_ovfl (int fd);
+
 #endif // UDX_IO_H

--- a/src/io_posix.c
+++ b/src/io_posix.c
@@ -102,6 +102,8 @@ udx__recvmsg (udx_socket_t *handle, uv_buf_t *buf, struct sockaddr *addr, int ad
     size = recvmsg(handle->io_poll.io_watcher.fd, &h, 0);
   } while (size == -1 && errno == EINTR);
 
+#if defined(__linux__)
+
   // relies on SO_RXQ_OVFL being set
   uint32_t packets_dropped_by_kernel = 0;
 
@@ -115,6 +117,8 @@ udx__recvmsg (udx_socket_t *handle, uv_buf_t *buf, struct sockaddr *addr, int ad
     handle->packets_dropped_by_kernel = packets_dropped_by_kernel;
   }
 
+#endif
+
   return size == -1 ? uv_translate_sys_error(errno) : size;
 }
 
@@ -127,6 +131,7 @@ udx__udp_set_rxq_ovfl (int fd) {
 #else
 int
 udx__udp_set_rxq_ovfl (int fd) {
+  UDX_UNUSED(fd);
   return -1;
 }
 #endif

--- a/src/io_win.c
+++ b/src/io_win.c
@@ -81,3 +81,8 @@ udx__recvmsg (udx_socket_t *socket, uv_buf_t *buf, struct sockaddr *addr, int ad
 
   return bytes;
 }
+
+int
+udx__udp_set_rxq_ovfl (int fd) {
+  return -1;
+}

--- a/src/io_win.c
+++ b/src/io_win.c
@@ -84,5 +84,6 @@ udx__recvmsg (udx_socket_t *socket, uv_buf_t *buf, struct sockaddr *addr, int ad
 
 int
 udx__udp_set_rxq_ovfl (int fd) {
+  UDX_UNUSED(fd);
   return -1;
 }

--- a/src/udx.c
+++ b/src/udx.c
@@ -1938,7 +1938,7 @@ udx_socket_init (udx_t *udx, udx_socket_t *socket) {
   socket->packets_rx = 0;
   socket->packets_tx = 0;
 
-  socket->npackets_dropped_since_last_recv = -1;
+  socket->packets_dropped_by_kernel = -1;
   socket->cmsg_wanted = false;
 
   uv_udp_t *handle = &(socket->handle);
@@ -2033,7 +2033,7 @@ udx_socket_bind (udx_socket_t *socket, const struct sockaddr *addr, unsigned int
   err = udx__udp_set_rxq_ovfl(fd);
   if (!err) {
     socket->cmsg_wanted = true;
-    socket->npackets_dropped_since_last_recv = 0;
+    socket->packets_dropped_by_kernel = 0;
   }
 
   socket->status |= UDX_SOCKET_BOUND;

--- a/test/stream-write-read-perf.c
+++ b/test/stream-write-read-perf.c
@@ -149,5 +149,10 @@ main () {
   printf("stats: stream a: bytes_rx=%" PRIu64 " packets_rx=%" PRIu64 " bytes_tx=%" PRIu64 " packets_tx=%" PRIu64 "\n", astream.bytes_rx, astream.packets_rx, astream.bytes_tx, astream.packets_tx);
   printf("stats: stream b: bytes_rx=%" PRIu64 " packets_rx=%" PRIu64 " bytes_tx=%" PRIu64 " packets_tx=%" PRIu64 "\n", bstream.bytes_rx, bstream.packets_rx, bstream.bytes_tx, bstream.packets_tx);
 
+  if (asock.packets_dropped_by_kernel != -1 && bsock.packets_dropped_by_kernel != -1) {
+    printf("stats: socket a: packets_dropped=%" PRIi64 "\n", asock.packets_dropped_by_kernel);
+    printf("stats: socket b: packets_dropped=%" PRIi64 "\n", bsock.packets_dropped_by_kernel);
+  }
+
   return 0;
 }


### PR DESCRIPTION
Adds a new socket stat "packets_dropped_by_kernel" to track the number of packets that have been dropped from the socket receive buffer over the lifetime of the socket. 

This uses the Linux-only socket option SO_RXQ_OVFL, on other platform this stat is set to -1. nevertheless it may be useful to track.