### PR TITLE
Add receive window to udx

### DIFF
--- a/include/udx.h
+++ b/include/udx.h
@@ -49,9 +49,10 @@ extern "C" {
 #define UDX_HEADER_MESSAGE 0b01000
 #define UDX_HEADER_DESTROY 0b10000
 
-#define UDX_STREAM_WRITE_WANT_STATE   0b001
-#define UDX_STREAM_WRITE_WANT_TLP     0b010
-#define UDX_STREAM_WRITE_WANT_DESTROY 0b100
+#define UDX_STREAM_WRITE_WANT_STATE   0b0001
+#define UDX_STREAM_WRITE_WANT_TLP     0b0010
+#define UDX_STREAM_WRITE_WANT_DESTROY 0b0100
+#define UDX_STREAM_WRITE_WANT_ZWP     0b1000
 
 typedef struct {
   uint32_t seq;
@@ -190,6 +191,7 @@ struct udx_stream_s {
   uint32_t high_seq; // seq at time of congestion, marks end of recovery
   bool hit_high_watermark;
   uint16_t rto_count;
+  uint16_t zwp_count;
   uint16_t fast_recovery_count;
   uint16_t retransmit_count;
   size_t writes_queued_bytes;
@@ -227,9 +229,9 @@ struct udx_stream_s {
   int mtu_max;        // min(UDX_MTU_MAX, get_link_mtu(remote_addr))
   uint16_t mtu;
 
-  uint32_t seq;
-  uint32_t ack;
-  uint32_t remote_acked;
+  uint32_t seq;          // tcp snd.nxt
+  uint32_t ack;          // tcp rcv.nxt
+  uint32_t remote_acked; // tcp snd.una
   uint32_t remote_ended;
 
   uint32_t srtt;
@@ -256,14 +258,19 @@ struct udx_stream_s {
   uv_timer_t rto_timer;
   uv_timer_t rack_reo_timer;
   uv_timer_t tlp_timer;
+  uv_timer_t zwp_timer;
 
   size_t inflight;
 
   uint32_t sacks;
   uint32_t ssthresh;
-  uint32_t cwnd;
+  uint32_t cwnd; // packets
   uint32_t cwnd_cnt;
-  uint32_t rwnd;
+  uint32_t recv_rwnd; // tcp: rcv.wnd. bytes
+  uint32_t send_rwnd; // remote advertised rwnd
+
+  uint32_t send_wl1; // seq at last window update
+  uint32_t send_wl2; // ack at last window update
 
   // congestion state
   udx_cong_t cong;
@@ -294,7 +301,6 @@ struct udx_packet_s {
 
   bool lost;
   bool retransmitted;
-  bool is_tlp;
   uint8_t transmits;
   uint8_t rto_timeouts;
   bool is_mtu_probe;

--- a/src/udx.c
+++ b/src/udx.c
@@ -45,6 +45,7 @@
 #define UDX_CONG_MAX_CWND    65536
 #define UDX_RTO_MAX_MS       30000
 #define UDX_RTT_MAX_MS       30000
+#define UDX_INIT_RWND_BYTES  131072 // arbitrary, ~90 1500 mtu packets, 52mbits/sec at 20millis latency
 
 #define UDX_HIGH_WATERMARK 262144
 
@@ -131,6 +132,22 @@ cwnd_in_bytes (udx_stream_t *stream) {
   return stream->cwnd * max_payload(stream);
 }
 
+static inline uint32_t
+send_window_in_bytes (udx_stream_t *stream) {
+  return min_uint32(cwnd_in_bytes(stream), stream->send_rwnd);
+}
+
+// rounds down
+static inline uint32_t
+send_rwnd_in_packets (udx_stream_t *stream) {
+  return stream->send_rwnd / max_payload(stream);
+}
+
+static inline uint32_t
+send_window_in_packets (udx_stream_t *stream) {
+  return min_uint32(stream->cwnd, send_rwnd_in_packets(stream));
+}
+
 static void
 on_uv_poll (uv_poll_t *handle, int status, int events);
 
@@ -196,6 +213,11 @@ udx__close_handles (udx_socket_t *socket) {
 }
 
 static bool
+stream_has_data (udx_stream_t *stream) {
+  return stream->write_queue.len > 0 || stream->retransmit_queue.len > 0 || stream->unordered_queue.len > 0;
+}
+
+static bool
 stream_write_wanted (udx_stream_t *stream) {
   if (!(stream->status & UDX_STREAM_CONNECTED)) {
     return false;
@@ -210,7 +232,7 @@ stream_write_wanted (udx_stream_t *stream) {
     return true;
   }
 
-  return stream->inflight_queue.len < stream->cwnd && ((stream->write_queue.len > 0) || stream->retransmit_queue.len > 0 || stream->unordered_queue.len > 0);
+  return stream->inflight_queue.len < send_window_in_packets(stream) && stream_has_data(stream);
 }
 
 static bool
@@ -383,6 +405,7 @@ clear_incoming_packets (udx_stream_t *stream) {
 
 int
 udx_stream_write_sizeof (int nwbufs) {
+  assert(nwbufs > 0); // must have at least one nwbuf
   return sizeof(udx_stream_write_t) + sizeof(udx_stream_write_buf_t) * nwbufs;
 }
 
@@ -406,7 +429,11 @@ on_bytes_acked (udx_stream_write_buf_t *wbuf, size_t bytes, bool cancelled) {
   assert(bytes <= stream->writes_queued_bytes);
   stream->writes_queued_bytes -= bytes;
 
-  if (stream->hit_high_watermark && stream->writes_queued_bytes < UDX_HIGH_WATERMARK + cwnd_in_bytes(stream)) {
+  // if high watermark (262k+send window bytes queued for writing was hit)
+  // stream->writes_queued_bytes > UDX_HIGH_WATERMARK + send_window_in_bytes(stream)
+  // and we are now below high watermark
+
+  if (stream->hit_high_watermark && stream->writes_queued_bytes < UDX_HIGH_WATERMARK + send_window_in_bytes(stream)) {
     stream->hit_high_watermark = false;
     if (stream->on_drain != NULL) stream->on_drain(stream);
   }
@@ -493,7 +520,7 @@ init_stream_packet (udx_packet_t *pkt, int type, udx_stream_t *stream, const uv_
   // 32 bit (le) remote id
   *(i++) = udx__swap_uint32_if_be(stream->remote_id);
   // 32 bit (le) recv window
-  *(i++) = 0xffffffff; // hardcode max recv window
+  *(i++) = udx__swap_uint32_if_be(stream->recv_rwnd);
   // 32 bit (le) seq
   *(i++) = udx__swap_uint32_if_be(stream->seq);
   // 32 bit (le) ack
@@ -508,7 +535,6 @@ init_stream_packet (udx_packet_t *pkt, int type, udx_stream_t *stream, const uv_
   pkt->dest = stream->remote_addr;
   pkt->dest_len = stream->remote_addr_len;
   pkt->is_mtu_probe = false;
-  pkt->is_tlp = false;
   pkt->lost = false;
 
   uv_buf_t *bufs = (uv_buf_t *) (pkt + 1);
@@ -652,10 +678,12 @@ close_stream (udx_stream_t *stream, int err) {
   uv_timer_stop(&stream->rto_timer);
   uv_timer_stop(&stream->rack_reo_timer);
   uv_timer_stop(&stream->tlp_timer);
+  uv_timer_stop(&stream->zwp_timer);
 
   uv_close((uv_handle_t *) &stream->rto_timer, finalize_maybe);
   uv_close((uv_handle_t *) &stream->rack_reo_timer, finalize_maybe);
   uv_close((uv_handle_t *) &stream->tlp_timer, finalize_maybe);
+  uv_close((uv_handle_t *) &stream->zwp_timer, finalize_maybe);
 
   if (stream->on_close != NULL) {
     stream->on_close(stream, err);
@@ -823,6 +851,22 @@ rack_detect_loss_and_arm_timer (uv_timer_t *timer) {
 }
 
 static void
+udx_zwp_timeout (uv_timer_t *timer) {
+  udx_stream_t *stream = timer->data;
+  assert(stream->status & UDX_STREAM_CONNECTED);
+  assert(stream->send_rwnd == 0);
+  assert((stream->status & UDX_STREAM_CLOSED) == 0);
+
+  stream->write_wanted |= UDX_STREAM_WRITE_WANT_ZWP;
+  stream->zwp_count++;
+  debug_printf("zwp: stream=%u\n", stream->remote_id);
+  if (stream->send_rwnd == 0) {
+    uv_timer_start(&stream->zwp_timer, udx_zwp_timeout, stream->rto, 0);
+  }
+  update_poll(stream->socket);
+}
+
+static void
 udx_rto_timeout (uv_timer_t *timer) {
   udx_stream_t *stream = timer->data;
   udx_socket_t *socket = stream->socket;
@@ -897,6 +941,10 @@ ack_update (udx_stream_t *stream, uint32_t acked, bool is_limited) {
   // The delay_min check here, was added due to massive latency increase (ie multiple seconds) due to router buffering
   // Perhaps research other approaches for this, but since delay_min is adjusted based on congestion this seems OK but
   // but surely better ways exists for this
+  // bt-utp uses a timestamp and timestamp_delta field that tracks 1-way delay between sender
+  // and receiver and throttles back when that latency increases
+  // https://www.bittorrent.org/beps/bep_0029.html
+
   if (is_limited || stream->ca_state != UDX_CA_OPEN || (c->delay_min > 0 && stream->srtt > c->delay_min * 4)) {
     c->start_time = 0;
     return;
@@ -1125,8 +1173,7 @@ process_data_packet (udx_stream_t *stream, int type, uint32_t seq, char *data, s
 }
 
 static int
-relay_packet (udx_stream_t *stream, char *buf, ssize_t buf_len, int type, uint8_t data_offset, uint32_t seq, uint32_t ack) {
-
+relay_packet (udx_stream_t *stream, char *buf, ssize_t buf_len, int type, uint8_t data_offset, uint32_t seq, uint32_t ack, uint32_t rwnd) {
   stream->seq = seq_max(stream->seq, seq);
 
   udx_stream_t *relay = stream->relay_to;
@@ -1163,7 +1210,7 @@ relay_packet (udx_stream_t *stream, char *buf, ssize_t buf_len, int type, uint8_
 
       uint32_t *i = (uint32_t *) p;
       *(i++) = udx__swap_uint32_if_be(stream->remote_id);
-      *(i++) = 0xffffffff;
+      *(i++) = udx__swap_uint32_if_be(rwnd);
       *(i++) = udx__swap_uint32_if_be(seq);
       *(i++) = udx__swap_uint32_if_be(ack);
 
@@ -1220,7 +1267,7 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
   uint32_t *i = (uint32_t *) b;
 
   uint32_t local_id = udx__swap_uint32_if_be(*(i++));
-  /* recv_win */ udx__swap_uint32_if_be(*(i++));
+  uint32_t rwnd = udx__swap_uint32_if_be(*(i++));
   uint32_t seq = udx__swap_uint32_if_be(*(i++));
   uint32_t ack = udx__swap_uint32_if_be(*i);
 
@@ -1244,7 +1291,7 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
     if (stream->on_firewall(stream, socket, addr)) return 1;
   }
 
-  if (stream->relay_to) return relay_packet(stream, buf, buf_len, type, data_offset, seq, ack);
+  if (stream->relay_to) return relay_packet(stream, buf, buf_len, type, data_offset, seq, ack, rwnd);
 
   buf += UDX_HEADER_SIZE;
   buf_len -= UDX_HEADER_SIZE;
@@ -1316,8 +1363,25 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
   }
 
   // Check if the ack is oob.
+  // could also check ack > remote_acked - send_window
   if (seq_compare(stream->seq, ack) < 0) {
     return 1;
+  }
+
+  if (seq_compare(ack, stream->remote_acked) >= 0) {
+    if (seq_compare(stream->send_wl1, seq) < 0 || (stream->send_wl1 == seq && seq_compare(stream->send_wl2, ack) <= 0)) {
+      // update send window
+      if (rwnd > 0) {
+        uv_timer_stop(&stream->zwp_timer);
+      }
+      stream->send_rwnd = rwnd;
+      stream->send_wl1 = seq;
+      stream->send_wl2 = ack;
+
+      if (rwnd == 0) {
+        uv_timer_start(&stream->zwp_timer, udx_zwp_timeout, stream->rto, 0);
+      }
+    }
   }
 
   if (stream->remote_changing && seq_diff(ack, stream->seq_on_remote_changed) >= 0) {
@@ -1335,6 +1399,7 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
   }
 
   int32_t len = seq_diff(ack, stream->remote_acked);
+
   bool is_limited = stream->ca_state == UDX_CA_RECOVERY || stream->ca_state == UDX_CA_LOSS;
 
   for (int32_t j = 0; j < len; j++) {
@@ -1382,7 +1447,8 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
   }
 
   // we are user limited if queued bytes (that includes current inflight + a max packet) is less than the window
-  if (!is_limited) is_limited = stream->writes_queued_bytes + max_payload(stream) < cwnd_in_bytes(stream);
+  // we are rwnd limited if rwnd < cwnd
+  if (!is_limited) is_limited = stream->writes_queued_bytes + max_payload(stream) < cwnd_in_bytes(stream) || send_rwnd_in_packets(stream) < stream->cwnd;
 
   if (len > 0) {
     ack_update(stream, len, is_limited);
@@ -1435,7 +1501,7 @@ check_if_streams_have_data (udx_socket_t *socket) {
       if (stream->status & UDX_STREAM_DEAD) {
         if (stream->write_wanted & (UDX_STREAM_WRITE_WANT_DESTROY | UDX_STREAM_WRITE_WANT_STATE)) return true;
       } else {
-        if (stream->write_wanted || stream->write_queue.len > 0 || stream->retransmit_queue.len > 0 || stream->unordered_queue.len > 0) return true;
+        if (stream->write_wanted || stream_has_data(stream)) return true;
       }
     }
   }
@@ -1505,6 +1571,11 @@ send_datagrams (udx_socket_t *socket) {
     }
   }
   return true;
+}
+
+static bool
+stream_may_send (udx_stream_t *stream) {
+  return stream->inflight_queue.len < send_window_in_packets(stream) || stream->write_wanted & UDX_STREAM_WRITE_WANT_ZWP;
 }
 
 static bool
@@ -1634,7 +1705,7 @@ send_stream_packets (udx_socket_t *socket, udx_stream_t *stream) {
     return true;
   }
 
-  while (stream->retransmit_queue.len > 0 && stream->inflight_queue.len < stream->cwnd) {
+  while (stream->retransmit_queue.len > 0 && stream_may_send(stream)) {
     udx_packet_t *pkt = udx__queue_data(udx__queue_peek(&stream->retransmit_queue), udx_packet_t, queue);
     assert(pkt != NULL);
 
@@ -1652,12 +1723,17 @@ send_stream_packets (udx_socket_t *socket, udx_stream_t *stream) {
     stream->bytes_tx += pkt->size;
     stream->retransmit_count++;
 
+    if (stream->write_wanted & UDX_STREAM_WRITE_WANT_ZWP) {
+      stream->write_wanted &= ~UDX_STREAM_WRITE_WANT_ZWP;
+    }
+
     arm_stream_timers(stream, false);
   }
 
-  while (stream->write_queue.len > 0 && (stream->inflight_queue.len < stream->cwnd || stream->write_wanted & UDX_STREAM_WRITE_WANT_TLP)) {
+  while (stream->write_queue.len > 0 && (stream_may_send(stream) || stream->write_wanted & UDX_STREAM_WRITE_WANT_TLP)) {
 
     bool tlp = stream->write_wanted & UDX_STREAM_WRITE_WANT_TLP;
+    bool zwp = stream->write_wanted & UDX_STREAM_WRITE_WANT_ZWP;
 
     // header_flag will be either
     // DATA     - packet has payload and all data written with udx_stream_write()
@@ -1768,10 +1844,19 @@ send_stream_packets (udx_socket_t *socket, udx_stream_t *stream) {
       stream->tlp_permitted = false;
     }
 
+    if (zwp) {
+      stream->write_wanted &= ~UDX_STREAM_WRITE_WANT_ZWP;
+    }
+
     arm_stream_timers(stream, tlp);
   }
 
   assert(stream->status != UDX_STREAM_CLOSED);
+
+  if (stream->write_wanted & UDX_STREAM_WRITE_WANT_ZWP && stream->write_queue.len == 0 && stream->retransmit_queue.len == 0) {
+    // if there's no data then we don't need to probe the window anyways.
+    stream->write_wanted &= ~UDX_STREAM_WRITE_WANT_ZWP;
+  }
 
   if (stream->write_wanted & UDX_STREAM_WRITE_WANT_TLP && stream->write_queue.len == 0) {
     // rack 7.3
@@ -1831,6 +1916,8 @@ arm_stream_timers (udx_stream_t *stream, bool sent_tlp) {
       schedule_loss_probe(stream);
     }
   }
+
+  uv_timer_stop(&stream->zwp_timer);
 }
 
 static void
@@ -2157,6 +2244,7 @@ udx_stream_init (udx_t *udx, udx_stream_t *stream, uint32_t local_id, udx_stream
 
   stream->reordering_seen = false;
   stream->rto_count = 0;
+  stream->zwp_count = 0;
   stream->fast_recovery_count = 0;
   stream->retransmit_count = 0;
 
@@ -2205,7 +2293,11 @@ udx_stream_init (udx_t *udx, udx_stream_t *stream, uint32_t local_id, udx_stream
   uv_timer_init(udx->loop, &stream->tlp_timer);
   stream->tlp_timer.data = stream;
 
-  stream->nrefs = 3;
+  memset(&stream->zwp_timer, 0, sizeof(uv_timer_t));
+  uv_timer_init(udx->loop, &stream->zwp_timer);
+  stream->zwp_timer.data = stream;
+
+  stream->nrefs = 4;
   stream->deferred_ack = 0;
 
   udx__queue_init(&stream->inflight_queue);
@@ -2220,8 +2312,8 @@ udx_stream_init (udx_t *udx, udx_stream_t *stream, uint32_t local_id, udx_stream
   stream->ssthresh = 255;
   stream->cwnd = UDX_CONG_INIT_CWND;
   stream->cwnd_cnt = 0;
-  stream->rwnd = 0;
-
+  stream->recv_rwnd = UDX_INIT_RWND_BYTES;
+  stream->send_rwnd = UDX_INIT_RWND_BYTES;
   stream->on_firewall = NULL;
   stream->on_read = NULL;
   stream->on_recv = NULL;
@@ -2508,6 +2600,12 @@ _udx_stream_write (udx_stream_write_t *write, udx_stream_t *stream, const uv_buf
     }
     udx__queue_tail(&stream->write_queue, &wbuf->queue);
   }
+
+  // if an idle, zero window stream has data queued, send a zero-window probe immediately
+  if (stream->writes_queued_bytes > 0 && stream->send_rwnd == 0) {
+    stream->write_wanted |= UDX_STREAM_WRITE_WANT_ZWP;
+    uv_timer_start(&stream->zwp_timer, udx_zwp_timeout, stream->rto, 0);
+  }
 }
 
 int
@@ -2521,7 +2619,7 @@ udx_stream_write (udx_stream_write_t *req, udx_stream_t *stream, const uv_buf_t 
   int err = update_poll(stream->socket);
   if (err < 0) return err;
 
-  if (stream->writes_queued_bytes > UDX_HIGH_WATERMARK + cwnd_in_bytes(stream)) {
+  if (stream->writes_queued_bytes > UDX_HIGH_WATERMARK + send_window_in_bytes(stream)) {
     stream->hit_high_watermark = true;
     return 0;
   }
@@ -2545,7 +2643,7 @@ udx_stream_write_end (udx_stream_write_t *req, udx_stream_t *stream, const uv_bu
   int err = update_poll(stream->socket);
   if (err < 0) return err;
 
-  if (stream->writes_queued_bytes > UDX_HIGH_WATERMARK + cwnd_in_bytes(stream)) {
+  if (stream->writes_queued_bytes > UDX_HIGH_WATERMARK + send_window_in_bytes(stream)) {
     stream->hit_high_watermark = true;
     return 0;
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@ list(APPEND tests
   stream-write-read-perf
   stream-change-remote
   stream-multiple
+  stream-write-read-receive-window
 )
 
 list(APPEND skipped_tests

--- a/test/stream-write-read-receive-window.c
+++ b/test/stream-write-read-receive-window.c
@@ -1,0 +1,148 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../include/udx.h"
+
+uv_loop_t loop;
+udx_t udx;
+
+udx_socket_t recv_sock;
+udx_stream_t recv_stream;
+
+udx_socket_t send_sock;
+udx_stream_t send_stream;
+
+udx_stream_write_t *req;
+
+int read_counter;
+int nprobe_timeouts;
+uint64_t start_time_ms;
+
+bool ack_called;
+
+udx_stream_write_t *send_end_req;
+udx_stream_write_t *recv_end_req;
+
+int nend;
+int nstream_close;
+int nsocket_close;
+int nfinalize;
+
+void
+on_end (udx_stream_write_t *req, int status, int unordered) {
+  nend++;
+}
+
+void
+on_close (udx_stream_t *stream, int status) {
+  nstream_close++;
+}
+
+void
+on_socket_close (udx_socket_t *s) {
+  nsocket_close++;
+}
+
+void
+on_finalize (udx_stream_t *stream) {
+  nfinalize++;
+  if (nfinalize == 2) {
+    udx_socket_close(&send_sock, on_socket_close);
+    udx_socket_close(&recv_sock, on_socket_close);
+  }
+}
+
+void
+on_ack (udx_stream_write_t *req, int status, int unordered) {
+  assert(status == 0);
+  assert(unordered == 0);
+
+  ack_called = true;
+  send_end_req = malloc(udx_stream_write_sizeof(1));
+  recv_end_req = malloc(udx_stream_write_sizeof(1));
+
+  udx_stream_write_end(send_end_req, &send_stream, NULL, 0, on_end);
+  udx_stream_write_end(recv_end_req, &recv_stream, NULL, 0, on_end);
+}
+
+void
+on_read (udx_stream_t *handle, ssize_t read_len, const uv_buf_t *buf) {
+  read_counter++;
+
+  // zwp_count only counts the number of zwp timeouts, since we start with a zero window
+  // we automatically probe (without waiting for a timeout) when data is queued.
+  // why reac_counter == 2 ? because:
+  // read_counter 1: 'free' zwp fired when initially queueing data ona stream with zero window
+  // read_counter 2: read fired from the first zero window probe triggered by timeout.
+
+  if (read_counter == 2) {
+    recv_stream.recv_rwnd = 131072;
+  }
+}
+
+int
+main () {
+  int e;
+
+  req = malloc(udx_stream_write_sizeof(1));
+
+  uv_loop_init(&loop);
+
+  e = udx_init(&loop, &udx);
+  assert(e == 0);
+
+  e = udx_socket_init(&udx, &recv_sock);
+  assert(e == 0);
+
+  e = udx_socket_init(&udx, &send_sock);
+  assert(e == 0);
+
+  struct sockaddr_in send_addr;
+  uv_ip4_addr("127.0.0.1", 8082, &send_addr);
+  e = udx_socket_bind(&send_sock, (struct sockaddr *) &send_addr, 0);
+  assert(e == 0);
+
+  struct sockaddr_in recv_addr;
+  uv_ip4_addr("127.0.0.1", 8081, &recv_addr);
+  e = udx_socket_bind(&recv_sock, (struct sockaddr *) &recv_addr, 0);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &recv_stream, 1, on_close, on_finalize);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &send_stream, 2, on_close, on_finalize);
+  assert(e == 0);
+
+  recv_stream.recv_rwnd = 0;
+  send_stream.send_rwnd = 0;
+  assert(recv_stream.rto == 1000);
+
+  e = udx_stream_connect(&recv_stream, &recv_sock, 2, (struct sockaddr *) &send_addr);
+  assert(e == 0);
+
+  e = udx_stream_connect(&send_stream, &send_sock, 1, (struct sockaddr *) &recv_addr);
+  assert(e == 0);
+
+  e = udx_stream_read_start(&recv_stream, on_read);
+  assert(e == 0);
+
+  int data_sz = UDX_MTU_MAX * 6;
+  uint8_t *data = malloc(data_sz);
+  uv_buf_t buf = uv_buf_init(data, data_sz);
+
+  e = udx_stream_write(req, &send_stream, &buf, 1, on_ack);
+  assert(e && "drained");
+
+  uv_run(&loop, UV_RUN_DEFAULT);
+
+  // zwp_count only counts the number of zwp timeouts, since we start with a zero window
+  // we automatically probe (without waiting for a timeout) when data is queued.
+
+  assert(send_stream.zwp_count == 1 && recv_stream.zwp_count == 0 && ack_called && send_stream.retransmit_count == 0 && recv_stream.retransmit_count == 0);
+  assert(nend == 2 && nstream_close == 2 && nfinalize == 2 && nsocket_close == 2);
+  free(data);
+
+  return 0;
+}


### PR DESCRIPTION
Adds a receive window (rwnd) to UDX.

- sets the rwnd field, and respects the rwnd on the sender side
- if the receive window is full, sets a timer to send a new packet as a zero-window-probe 

based on TCP's receive window, for more info: https://datatracker.ietf.org/doc/html/rfc9293