### PR TITLE
Use `lib` as static library prefix on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ set_target_properties(
   udx_static
   PROPERTIES
   OUTPUT_NAME udx
+  PREFIX lib
 )
 
 target_link_libraries(


### PR DESCRIPTION
This prevents the static library from colliding with the DLL import library.