### PR TITLE
defer adding padding to probe packets to simplify code, fix stream corruption on EAGAIN of packet containing multiple write-buffers

### DIFF
--- a/include/udx.h
+++ b/include/udx.h
@@ -315,10 +315,6 @@ struct udx_packet_s {
   // just alloc it in place here, easier to manage
   char header[UDX_HEADER_SIZE];
   unsigned short nbufs;
-
-  // inefficient - only relevant for stream_t packets
-  unsigned short nwbufs;
-  udx_stream_write_buf_t **wbufs;
 };
 
 struct udx_socket_send_s {


### PR DESCRIPTION
This PR defers adding an explicit padding buffer to the mtu probe packets until just before the buffers are sent to sendmsg(). This simplifies code that iterates the packets by removing special cases for padding packets.

It more importantly fixes a stream corruption bug on EAGAIN of a packet containing multiple complete wbufs. these wbufs that failed to send would be added back to the stream->write_queue in reverse order, which would corrupt the stream.
