### PR TITLE
early return on reentry in ack_packet

### DIFF
--- a/src/udx.c
+++ b/src/udx.c
@@ -1070,12 +1070,16 @@ ack_packet (udx_stream_t *stream, uint32_t seq, int sack) {
 
     if (write->bytes_acked == write->size && write->on_ack) {
       write->on_ack(write, 0, sack);
+
+      // reentry from write->on_ack
+      if (stream->status & UDX_STREAM_DEAD) {
+        free(pkt);
+        return 2;
+      }
     }
   }
 
   free(pkt);
-
-  if (stream->status & UDX_STREAM_DEAD) return 2; // reentry from write->on_ack
 
   // TODO: the end condition needs work here to be more "stateless"
   // ie if the remote has acked all our writes, then instead of waiting for retransmits, we should


### PR DESCRIPTION
If a stream is closed during the callback `write->on_ack` then `clear_outgoing_packets` acks all writes and frees all packets. On reentry we may try to ack one of these closed writes again, triggering an assert in `on_bytes_acked`

this PR adds a check to see if the stream is closed on re-entry so that we do not try to re-acknowledge a closed write.
