### PR TITLE
[wip] maximum packet retransmission

### DIFF
--- a/include/udx.h
+++ b/include/udx.h
@@ -178,6 +178,7 @@ struct udx_socket_s {
   uint64_t packets_tx;
 
   int64_t packets_dropped_by_kernel;
+  uint32_t debug_force_recv_drop;
 };
 
 typedef struct udx_cong_s {

--- a/src/udx.c
+++ b/src/udx.c
@@ -760,6 +760,12 @@ rack_detect_loss (udx_stream_t *stream) {
     udx_packet_t *pkt = udx__queue_data(p, udx_packet_t, queue);
     assert(pkt->transmits > 0);
 
+    if (pkt->transmits == 254) {
+      debug_printf("pkt seq=%i, max retransmits reached.\n", pkt->seq);
+      close_stream(stream, UV_ETIMEDOUT);
+      return 0;
+    }
+
     if (pkt->time_sent > stream->rack_time_sent) {
       break;
     }

--- a/src/udx.c
+++ b/src/udx.c
@@ -1941,6 +1941,9 @@ on_uv_poll (uv_poll_t *handle, int status, int events) {
     buf.len = 2048;
 
     while (!(socket->status & UDX_SOCKET_CLOSED) && (size = udx__recvmsg(socket, &buf, (struct sockaddr *) &addr, addr_len)) >= 0) {
+
+      if (socket->debug_force_recv_drop && !(socket->debug_force_recv_drop++ % 2)) continue;
+
       if (!process_packet(socket, b, size, (struct sockaddr *) &addr) && socket->on_recv != NULL) {
         buf.len = size;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ list(APPEND tests
   stream-change-remote
   stream-multiple
   stream-write-read-receive-window
+  stream-lossy-recv
 )
 
 list(APPEND skipped_tests

--- a/test/stream-lossy-recv.c
+++ b/test/stream-lossy-recv.c
@@ -1,0 +1,133 @@
+#include "assert.h"
+#include <stdlib.h>
+#include <memory.h>
+
+#include "../include/udx.h"
+
+uv_loop_t loop;
+udx_t udx;
+
+udx_socket_t asock;
+udx_stream_t astream;
+
+udx_socket_t bsock;
+udx_stream_t bstream;
+
+#define STRIDE 1024
+#define N_SAMPLES 1024
+
+static size_t read_offset = 0;
+void
+on_read (udx_stream_t *handle, ssize_t read_len, const uv_buf_t *buf) {
+  size_t o = 0;
+
+  while (o < read_len) {
+    if (!(read_offset % STRIDE)) {
+      int i = *(uint32_t *)(buf->base + o);
+      printf("on_a_read, read_offset=%zu len=%zi i=%i\n", read_offset, read_len, i);
+      if (i == N_SAMPLES - 1) {
+        udx_stream_destroy(handle);
+      }
+    }
+    o++;
+    read_offset++;
+  }
+}
+
+static void
+on_a_sock_close () {
+  printf("receiving socket closed\n");
+}
+
+static void
+on_b_sock_close () {
+  printf("transmitting socket closing\n");
+}
+
+static void
+on_a_stream_close () {
+  printf("rx stream closed, teardown\n");
+}
+
+static void
+on_b_stream_close () {
+  printf("tx stream closed\n");
+}
+
+static void
+on_ack (udx_stream_write_t *req, int status, int unordered) {
+  // printf("ack status=%i unordered=%i\n", status, unordered);
+  free(req);
+}
+
+static void
+send_data (udx_stream_t *stream) {
+  printf("on drain\n");
+}
+
+int
+main () {
+  int e;
+
+  e = uv_loop_init(&loop);
+  assert(e == 0);
+
+  e = udx_init(&loop, &udx, NULL);
+  assert(e == 0);
+
+  e = udx_socket_init(&udx, &asock, on_a_sock_close);
+  assert(e == 0);
+  asock.debug_force_recv_drop = 2;
+
+  e = udx_socket_init(&udx, &bsock, on_b_sock_close);
+  assert(e == 0);
+
+  struct sockaddr_in baddr;
+  uv_ip4_addr("127.0.0.1", 8082, &baddr);
+  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr, 0);
+  assert(e == 0);
+
+  struct sockaddr_in aaddr;
+  uv_ip4_addr("127.0.0.1", 8081, &aaddr);
+  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr, 0);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &astream, 1, on_a_stream_close, NULL);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &bstream, 2, on_b_stream_close, NULL);
+  assert(e == 0);
+
+  e = udx_stream_connect(&astream, &asock, 2, (struct sockaddr *) &baddr);
+  assert(e == 0);
+
+  e = udx_stream_connect(&bstream, &bsock, 1, (struct sockaddr *) &aaddr);
+  assert(e == 0);
+
+  e = udx_stream_read_start(&astream, on_read);
+  assert(e == 0);
+
+  char *buffer = calloc(N_SAMPLES, STRIDE);
+  memset(buffer, 0xaa, N_SAMPLES * STRIDE);
+
+  for (int i = 0; i < N_SAMPLES; i++) {
+    udx_stream_write_t *req = malloc(udx_stream_write_sizeof(1));
+
+    char *data = buffer + (i * STRIDE);
+    *((uint32_t *) data) = i;
+    uv_buf_t buf = { .base = data, .len = STRIDE };
+
+    e = udx_stream_write(req, &bstream, &buf, 1, on_ack); // returns UV_EEXIST?
+    // assert(e == 0);
+
+    udx_stream_write_resume(&bstream, send_data);
+  }
+
+  e = uv_run(&loop, UV_RUN_DEFAULT);
+  assert(e == 0 && "UV_RUN");
+
+  uv_loop_close(&loop);
+
+  free(buffer);
+  return 0;
+}

--- a/test/stream-lossy-recv.c
+++ b/test/stream-lossy-recv.c
@@ -24,7 +24,7 @@ on_read (udx_stream_t *handle, ssize_t read_len, const uv_buf_t *buf) {
   while (o < read_len) {
     if (!(read_offset % STRIDE)) {
       int i = *(uint32_t *)(buf->base + o);
-      printf("on_a_read, read_offset=%zu len=%zi i=%i\n", read_offset, read_len, i);
+      // printf("on_a_read, read_offset=%zu len=%zi i=%i\n", read_offset, read_len, i);
       if (i == N_SAMPLES - 1) {
         udx_stream_destroy(handle);
       }
@@ -52,11 +52,12 @@ on_a_stream_close () {
 static void
 on_b_stream_close () {
   printf("tx stream closed\n");
+  // exit test w/ success
+  exit(0);
 }
 
 static void
 on_ack (udx_stream_write_t *req, int status, int unordered) {
-  // printf("ack status=%i unordered=%i\n", status, unordered);
   free(req);
 }
 


### PR DESCRIPTION
Expressed issue as a test; 
added `debug_force_recv_drop` to trigger fault. Is there a less intrusive way?

Proposed fix;
close stream when a packet has failed to be received after 254 attempts.