### PR TITLE
Do not merge: idea to split stream->write_queue 

### DIFF
--- a/include/udx.h
+++ b/include/udx.h
@@ -298,6 +298,7 @@ struct udx_stream_s {
   // congestion state
   udx_cong_t cong;
 
+  udx_queue_t wbuf_queue;
   udx_queue_t write_queue;
 
   udx_cirbuf_t outgoing;
@@ -365,6 +366,7 @@ struct udx_stream_write_buf_s {
 
 struct udx_stream_write_s {
   size_t size;
+  udx_queue_node_t queue;
   size_t bytes_acked;
   bool is_write_end;
 


### PR DESCRIPTION
splits the `stream->write_queue` into `stream->write-queue` of user-submitted writes and `stream->wbuf_queue`, the queue of individual buffers that comprise the writes.

This simplifies clear_outgoing_packets but at the cost of removing some asserts.