### PR TITLE
Fix crash in mtu_probeify_packet()

### DIFF
--- a/src/udx.c
+++ b/src/udx.c
@@ -2629,6 +2629,9 @@ udx_stream_connect (udx_stream_t *stream, udx_socket_t *socket, uint32_t remote_
 
   if (mtu == -1 || mtu > UDX_MTU_MAX) {
     mtu = UDX_MTU_MAX;
+  } else if (mtu <= UDX_MTU_BASE) {
+    debug_printf("mtu: OS-Discovered pMTU to host is less than UDX_MTU_BASE (%u < %u), disabling MTU discovery\n", mtu, UDX_MTU_BASE);
+    stream->mtu_state = UDX_MTU_STATE_SEARCH_COMPLETE;
   }
 
   stream->mtu_max = mtu;


### PR DESCRIPTION
Disable MTU probing if the OS-Discovered pMTU (returned from `getsockopt(socket, IP_MTU,  )` is less than UDX_MTU_BASE (1200 bytes). This is a temporary fix to prevent the assert in mtu_probeify_packet() from triggering a crash when generating a probe to these hosts. It doesn't actually lower libudx's initial MTU below 1200, so if this OS-Discovered pMTU is correct these hosts will typically time out.

