### PR TITLE
add TIME-WAIT state

### DIFF
--- a/include/udx.h
+++ b/include/udx.h
@@ -32,15 +32,17 @@ extern "C" {
 #define UDX_SOCKET_BOUND     0b0010
 #define UDX_SOCKET_CLOSED    0b0100
 
-#define UDX_STREAM_CONNECTED     0b000000001
-#define UDX_STREAM_RECEIVING     0b000000010
-#define UDX_STREAM_READING       0b000000100
-#define UDX_STREAM_ENDING        0b000001000
-#define UDX_STREAM_ENDING_REMOTE 0b000010000
-#define UDX_STREAM_ENDED         0b000100000
-#define UDX_STREAM_ENDED_REMOTE  0b001000000
-#define UDX_STREAM_DESTROYING    0b010000000
-#define UDX_STREAM_CLOSED        0b100000000
+#define UDX_STREAM_CONNECTED      0b00000000001
+#define UDX_STREAM_RECEIVING      0b00000000010
+#define UDX_STREAM_READING        0b00000000100
+#define UDX_STREAM_ENDING         0b00000001000
+#define UDX_STREAM_ENDING_REMOTE  0b00000010000
+#define UDX_STREAM_ENDED          0b00000100000
+#define UDX_STREAM_ENDED_REMOTE   0b00001000000
+#define UDX_STREAM_NEED_TIME_WAIT 0b00010000000
+#define UDX_STREAM_TIME_WAIT      0b00100000000
+#define UDX_STREAM_DESTROYING     0b01000000000
+#define UDX_STREAM_CLOSED         0b10000000000
 
 #define UDX_HEADER_DATA    0b00001
 #define UDX_HEADER_END     0b00010
@@ -258,6 +260,8 @@ struct udx_stream_s {
   uint32_t remote_acked; // tcp snd.una
   uint32_t remote_ended;
 
+  uint32_t timewait_timeout_ms;
+
   uint32_t srtt;
   uint32_t rttvar;
   uint32_t rto;
@@ -279,6 +283,7 @@ struct udx_stream_s {
 
   // optimize: use one timer and a action (RTO, RACK_REO, TLP) variable
   int nrefs;
+
   uv_timer_t rto_timer;
   uv_timer_t rack_reo_timer;
   uv_timer_t tlp_timer;
@@ -501,6 +506,12 @@ udx_stream_get_ack (udx_stream_t *stream, uint32_t *ack);
 
 int
 udx_stream_set_ack (udx_stream_t *stream, uint32_t ack);
+
+int
+udx_stream_set_timewait_timeout_ms (udx_stream_t *stream, uint32_t timewait_timeout_ms);
+
+int
+udx_stream_get_timewait_timeout_ms (udx_stream_t *stream, uint32_t *timewait_timeout_ms);
 
 int
 udx_stream_get_rwnd_max (udx_stream_t *stream, uint32_t *rwnd_max);

--- a/test/stream-write-read-receive-window.c
+++ b/test/stream-write-read-receive-window.c
@@ -55,6 +55,7 @@ on_socket_close (udx_socket_t *s) {
 void
 on_finalize (udx_stream_t *stream) {
   nfinalize++;
+
   if (nfinalize == 2) {
     udx_socket_close(&send_sock);
     udx_socket_close(&recv_sock);
@@ -129,8 +130,12 @@ main () {
   e = udx_stream_init(&udx, &recv_stream, 1, on_close, on_finalize);
   assert(e == 0);
 
+  assert(udx_stream_set_timewait_timeout_ms(&recv_stream, 0) == 0);
+
   e = udx_stream_init(&udx, &send_stream, 2, on_close, on_finalize);
   assert(e == 0);
+
+  assert(udx_stream_set_timewait_timeout_ms(&send_stream, 0) == 0);
 
   recv_stream.get_read_buffer_size = &pretend_buffer_is_full;
   send_stream.send_rwnd = 0;

--- a/test/stream-write-read.c
+++ b/test/stream-write-read.c
@@ -21,6 +21,7 @@ bool read_called = false;
 bool eof_received = false;
 
 int nclosed;
+int nfinalized;
 
 void
 on_close (udx_stream_t *s, int status) {
@@ -29,8 +30,8 @@ on_close (udx_stream_t *s, int status) {
   nclosed++;
 
   if (nclosed == 2) {
-    udx_socket_close(&asock);
-    udx_socket_close(&bsock);
+    assert(0 == udx_socket_close(&asock));
+    assert(0 == udx_socket_close(&bsock));
   }
 }
 
@@ -89,6 +90,10 @@ main () {
 
   e = udx_stream_init(&udx, &bstream, 2, on_close, NULL);
   assert(e == 0);
+
+  assert(udx_stream_set_timewait_timeout_ms(&astream, 0) == 0);
+
+  assert(udx_stream_set_timewait_timeout_ms(&bstream, 0) == 0);
 
   e = udx_stream_connect(&astream, &asock, 2, (struct sockaddr *) &baddr);
   assert(e == 0);


### PR DESCRIPTION
Adds TIME-WAIT (from TCP) to libudx. The idea is to keep the socket active on the side that closes first (the 'active' closer) to retransmit the final ACK packet to the remote closer if necessary. without TIME-WAIT the stream would immediately close after sending an ACK for the final END packet; if this ACK is lost on the way to the remote closer, they would be left open until they time out.

One side effect of this change is the user callback `stream->on_close()` is delayed on active close until the TIME-WAIT state times out. This may be a problem in real code (e.g. during shutdown) or in unit tests. The PR also adds a way to get and set the timeout time for each stream, setting it to 0 will allow streams to shutdown with minimal wait.