### PR TITLE
Fix: sendmsg invalid args

### DIFF
--- a/include/udx.h
+++ b/include/udx.h
@@ -340,8 +340,8 @@ struct udx_packet_s {
   int dest_len;
 
   // just alloc it in place here, easier to manage
-  char header[UDX_HEADER_SIZE];
-  unsigned short nbufs;
+  uint8_t header[UDX_HEADER_SIZE];
+  uint16_t nbufs;
 };
 
 struct udx_socket_send_s {

--- a/src/udx.c
+++ b/src/udx.c
@@ -1488,7 +1488,7 @@ send_packet (udx_socket_t *socket, udx_packet_t *pkt) {
   uv_buf_t _bufs[UDX_MAX_COMBINED_WRITES + 2];
 
   if (pkt->is_mtu_probe) {
-    int padding_size = pkt->header[3];
+    size_t padding_size = pkt->header[3];
     static char probe_data[256] = {0};
     _bufs[0] = bufs[0];
     _bufs[1].base = probe_data;


### PR DESCRIPTION
The fix is changing pkt->header[20] to be uint8_t instead of char