### PR TITLE
Rate sampling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ target_sources(
     src/link.h
     src/io.h
     src/udx.c
+    src/udx_rate.c
 )
 
 target_include_directories(

--- a/include/udx.h
+++ b/include/udx.h
@@ -259,13 +259,13 @@ struct udx_stream_s {
   uint32_t remote_ended;
 
   // rate control
-  uint32_t delivered;        // number of packets delivered, including retransmits
-  uint32_t lost;             // number of packets lost, including retransmits
-  uint32_t app_limited;      // we are 'app limited' until delivered reaches this value
-  uint64_t first_time_sent;  // start of window send phase
-  uint64_t delivered_time;   // time we reached 'delivered'
-  uint32_t rate_delivered;   // saved rate sample: packets delivered
-  uint32_t rate_interval_ms; // saved rate sample: time elapsed
+  uint32_t delivered;           // number of packets delivered, including retransmits
+  uint32_t lost;                // number of packets lost, including retransmits
+  uint32_t app_limited;         // we are 'app limited' until delivered reaches this value
+  uint64_t interval_start_time; // start of window send phase
+  uint64_t delivered_time;      // time we reached 'delivered'
+  uint32_t rate_delivered;      // saved rate sample: packets delivered
+  uint32_t rate_interval_ms;    // saved rate sample: time elapsed
   bool rate_sample_is_app_limited;
 
   uint32_t srtt;
@@ -343,14 +343,13 @@ struct udx_packet_s {
   uint8_t transmits;
   uint8_t rto_timeouts;
   bool is_mtu_probe;
-  bool sacked;
   uint16_t size;
 
   uint64_t time_sent;
 
   // rate info
-  uint64_t first_time_sent;
-  uint64_t delivered_time; /* ?? */
+  uint64_t interval_start_time;
+  uint64_t delivered_time;
   uint32_t delivered;
   bool is_app_limited;
 

--- a/include/udx.h
+++ b/include/udx.h
@@ -258,6 +258,16 @@ struct udx_stream_s {
   uint32_t remote_acked; // tcp snd.una
   uint32_t remote_ended;
 
+  // rate control
+  uint32_t delivered;        // number of packets delivered, including retransmits
+  uint32_t lost;             // number of packets lost, including retransmits
+  uint32_t app_limited;      // we are 'app limited' until delivered reaches this value
+  uint64_t first_time_sent;  // start of window send phase
+  uint64_t delivered_time;   // time we reached 'delivered'
+  uint32_t rate_delivered;   // saved rate sample: packets delivered
+  uint32_t rate_interval_ms; // saved rate sample: time elapsed
+  bool rate_sample_is_app_limited;
+
   uint32_t srtt;
   uint32_t rttvar;
   uint32_t rto;
@@ -333,8 +343,16 @@ struct udx_packet_s {
   uint8_t transmits;
   uint8_t rto_timeouts;
   bool is_mtu_probe;
+  bool sacked;
   uint16_t size;
+
   uint64_t time_sent;
+
+  // rate info
+  uint64_t first_time_sent;
+  uint64_t delivered_time; /* ?? */
+  uint32_t delivered;
+  bool is_app_limited;
 
   struct sockaddr_storage dest;
   int dest_len;

--- a/src/internal.h
+++ b/src/internal.h
@@ -24,7 +24,7 @@ typedef struct {
   bool is_app_limited;
   bool is_retrans;
   bool is_ack_delayed;
-} rate_sample_t;
+} udx_rate_sample_t;
 
 static inline int32_t
 seq_diff (uint32_t a, uint32_t b) {
@@ -53,10 +53,10 @@ void
 udx__rate_pkt_sent (udx_stream_t *stream, udx_packet_t *pkt);
 
 void
-udx__rate_pkt_delivered (udx_stream_t *stream, udx_packet_t *pkt, rate_sample_t *rs);
+udx__rate_pkt_delivered (udx_stream_t *stream, udx_packet_t *pkt, udx_rate_sample_t *rs);
 
 void
-udx__rate_gen (udx_stream_t *stream, uint32_t delivered, uint32_t lost, bool is_sack_renege, rate_sample_t *rs);
+udx__rate_gen (udx_stream_t *stream, uint32_t delivered, uint32_t lost, bool is_sack_renege, udx_rate_sample_t *rs);
 
 void
 udx__rate_check_app_limited (udx_stream_t *stream);

--- a/src/internal.h
+++ b/src/internal.h
@@ -56,7 +56,7 @@ void
 udx__rate_pkt_delivered (udx_stream_t *stream, udx_packet_t *pkt, udx_rate_sample_t *rs);
 
 void
-udx__rate_gen (udx_stream_t *stream, uint32_t delivered, uint32_t lost, bool is_sack_renege, udx_rate_sample_t *rs);
+udx__rate_gen (udx_stream_t *stream, uint32_t delivered, uint32_t lost, udx_rate_sample_t *rs);
 
 void
 udx__rate_check_app_limited (udx_stream_t *stream);

--- a/src/internal.h
+++ b/src/internal.h
@@ -8,27 +8,57 @@
 
 #define UDX_UNUSED(x) ((void) (x))
 
-static inline void
-addr_to_v6 (struct sockaddr_in *addr) {
-  struct sockaddr_in6 in;
-  memset(&in, 0, sizeof(in));
+typedef struct {
+  uint64_t prior_timestamp;
+  uint32_t prior_delivered;
 
-  in.sin6_family = AF_INET6;
-  in.sin6_port = addr->sin_port;
-#ifdef SIN6_LEN
-  in.sin6_len = sizeof(struct sockaddr_in6);
-#endif
+  int32_t delivered;
+  int64_t interval_ms;
+  uint32_t snd_interval_ms;
+  uint32_t rcv_interval_ms;
+  long rtt_ms;
+  int losses;
+  uint32_t acked_sacked;
+  uint32_t prior_in_flight;
+  uint32_t seq;
+  bool is_app_limited;
+  bool is_retrans;
+  bool is_ack_delayed;
+} rate_sample_t;
 
-  in.sin6_addr.s6_addr[10] = 0xff;
-  in.sin6_addr.s6_addr[11] = 0xff;
-
-  // Copy the IPv4 address to the last 4 bytes of the IPv6 address.
-  memcpy(&(in.sin6_addr.s6_addr[12]), &(addr->sin_addr), 4);
-
-  memcpy(addr, &in, sizeof(in));
+static inline int32_t
+seq_diff (uint32_t a, uint32_t b) {
+  return a - b;
 }
+
+static inline int
+seq_compare (uint32_t a, uint32_t b) {
+  int32_t d = seq_diff(a, b);
+  return d < 0 ? -1 : d > 0 ? 1
+                            : 0;
+}
+
+static inline bool
+rack_sent_after (uint64_t t1, uint32_t seq1, uint64_t t2, uint32_t seq2) {
+  return t1 > t2 || (t1 == t2 && seq_compare(seq2, seq1) < 0);
+}
+
+uint32_t
+udx__max_payload (udx_stream_t *stream);
 
 void
 udx__close_handles (udx_socket_t *socket);
+
+void
+udx__rate_pkt_sent (udx_stream_t *stream, udx_packet_t *pkt);
+
+void
+udx__rate_pkt_delivered (udx_stream_t *stream, udx_packet_t *pkt, rate_sample_t *rs);
+
+void
+udx__rate_gen (udx_stream_t *stream, uint32_t delivered, uint32_t lost, bool is_sack_renege, rate_sample_t *rs);
+
+void
+udx__rate_check_app_limited (udx_stream_t *stream);
 
 #endif // UDX_INTERNAL_H

--- a/src/udx.c
+++ b/src/udx.c
@@ -1445,7 +1445,7 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
     }
   }
 
-  udx__rate_gen(stream, delivered, lost, false, &rs);
+  udx__rate_gen(stream, delivered, lost, &rs);
   // udx_cong_control(stream, ack, delivered, &rs);
 
   return 1;

--- a/src/udx_rate.c
+++ b/src/udx_rate.c
@@ -1,0 +1,116 @@
+
+#include "debug.h"
+#include "internal.h"
+
+static uint32_t
+max_uint32 (uint32_t a, uint32_t b) {
+  return a < b ? b : a;
+}
+
+// snapshot current delivery information in the packet,
+// to generate a rate sample later when packet is acked
+void
+udx__rate_pkt_sent (udx_stream_t *stream, udx_packet_t *pkt) {
+  if (stream->packets_tx == 1) {
+    // first packet was just sent
+    uint64_t now_ms = uv_now(stream->udx->loop);
+
+    stream->first_time_sent = now_ms;
+    stream->delivered_time = now_ms;
+  }
+
+  pkt->first_time_sent = stream->first_time_sent;
+}
+
+void
+udx__rate_pkt_delivered (udx_stream_t *stream, udx_packet_t *pkt, rate_sample_t *rs) {
+
+  if (!pkt->delivered_time) {
+    return;
+  }
+
+  if (!rs->prior_delivered || rack_sent_after(pkt->time_sent, stream->first_time_sent, pkt->seq, rs->seq)) {
+    rs->prior_delivered = pkt->delivered;
+    rs->prior_timestamp = pkt->delivered_time;
+    rs->is_app_limited = pkt->is_app_limited;
+    rs->is_retrans = pkt->retransmitted;
+    rs->seq = pkt->seq;
+
+    stream->first_time_sent = pkt->time_sent;
+
+    rs->interval_ms = stream->first_time_sent - pkt->first_time_sent;
+  }
+
+  // if (pkt->sacked) {
+  //   pkt->delivered_time = 0;
+  // }
+}
+
+static inline uint32_t
+stamp_ms_delta (uint64_t t1, uint64_t t0) {
+  return (int64_t) t1 - (int64_t) t0;
+}
+
+// generate a rate sample and store it in the udx_stream_t
+void
+udx__rate_gen (udx_stream_t *stream, uint32_t delivered, uint32_t lost, bool is_sack_reneg, rate_sample_t *rs) {
+  uint64_t now_ms = uv_now(stream->udx->loop);
+
+  // clear app limited if bubble is acked and gone
+  if (stream->app_limited && seq_compare(stream->delivered, stream->app_limited) > 0) {
+    stream->app_limited = 0;
+  }
+
+  if (delivered) {
+    stream->delivered_time = now_ms;
+  }
+
+  rs->acked_sacked = delivered;
+  rs->losses = lost;
+
+  if (!rs->prior_timestamp || is_sack_reneg) {
+    rs->delivered = -1;
+    rs->interval_ms = -1;
+    return;
+  }
+
+  rs->delivered = stream->delivered - rs->prior_delivered;
+
+  uint32_t snd_ms = rs->interval_ms;
+  uint32_t ack_ms = stamp_ms_delta(now_ms, rs->prior_timestamp);
+
+  rs->interval_ms = max_uint32(snd_ms, ack_ms);
+
+  rs->snd_interval_ms = snd_ms;
+  rs->rcv_interval_ms = ack_ms;
+
+  char *ca_state_string[] = {
+    "Unknown",
+    "UDX_CA_OPEN",
+    "UDX_CA_RECOVERY",
+    "UDX_CA_LOSS",
+  };
+
+  if (rs->interval_ms < stream->rack_rtt_min) {
+    if (!rs->is_retrans) {
+      debug_printf("rs->interval_ms=%ld, rs->delivered=%d, stream->ca_state=%s, stream->min_rtt=%u", rs->interval_ms, rs->delivered, ca_state_string[stream->ca_state], stream->rack_rtt_min);
+    }
+    rs->interval_ms = -1;
+    return;
+  }
+
+  if (!rs->is_app_limited || ((uint64_t) rs->delivered * stream->rate_interval_ms >= (uint64_t) stream->rate_delivered * rs->interval_ms)) {
+    stream->rate_delivered = rs->delivered;
+    stream->rate_interval_ms = rs->interval_ms;
+    stream->rate_sample_is_app_limited = rs->is_app_limited;
+  }
+}
+
+void
+udx__rate_check_app_limited (udx_stream_t *stream) {
+  if (stream->writes_queued_bytes < udx__max_payload(stream) &&
+      stream->inflight_queue.len < stream->cwnd &&
+      stream->retransmit_queue.len == 0) {
+    stream->app_limited = stream->delivered + stream->inflight_queue.len ?: 1;
+  }
+}

--- a/src/udx_rate.c
+++ b/src/udx_rate.c
@@ -54,7 +54,7 @@ udx__rate_pkt_delivered (udx_stream_t *stream, udx_packet_t *pkt, udx_rate_sampl
 
 // generate a rate sample and store it in the udx_stream_t
 void
-udx__rate_gen (udx_stream_t *stream, uint32_t delivered, uint32_t lost, bool is_sack_reneg, udx_rate_sample_t *rs) {
+udx__rate_gen (udx_stream_t *stream, uint32_t delivered, uint32_t lost, udx_rate_sample_t *rs) {
   uint64_t now_ms = uv_now(stream->udx->loop);
 
   // clear app limited if bubble is acked and gone
@@ -69,7 +69,7 @@ udx__rate_gen (udx_stream_t *stream, uint32_t delivered, uint32_t lost, bool is_
   rs->acked_sacked = delivered;
   rs->losses = lost;
 
-  if (!rs->prior_timestamp || is_sack_reneg) {
+  if (!rs->prior_timestamp) {
     rs->delivered = -1;
     rs->interval_ms = -1;
     return;


### PR DESCRIPTION
This PR tracks the sending rate and delivery rate of streams in udx. A rate sample is computed whenever an ACK is received, and contains information about the sending rate and delivery rate since a previous sample was computed.

It also makes two unrelated changes:
1. moves the SACK logic after the ACK is validated
2. on ending recovery / loss, sets cwnd = ssthresh