### PR TITLE
Windowed min/max filter and track windowed rtt_min

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ target_sources(
     src/io.h
     src/udx.c
     src/udx_rate.c
+    src/win_filter.h
+    src/win_filter.c
 )
 
 target_include_directories(

--- a/include/udx.h
+++ b/include/udx.h
@@ -78,6 +78,15 @@ typedef struct udx_stream_send_s udx_stream_send_t;
 typedef struct udx_stream_write_s udx_stream_write_t;
 typedef struct udx_stream_write_buf_s udx_stream_write_buf_t;
 
+typedef struct {
+  uint64_t t;
+  uint32_t v;
+} win_filter_entry_t;
+
+typedef struct {
+  win_filter_entry_t entries[3];
+} win_filter_t;
+
 typedef enum {
   UDX_LOOKUP_FAMILY_IPV4 = 1,
   UDX_LOOKUP_FAMILY_IPV6 = 2,
@@ -272,8 +281,9 @@ struct udx_stream_s {
   uint32_t rttvar;
   uint32_t rto;
 
+  win_filter_t rtt_min;
+
   // rack data...
-  uint32_t rack_rtt_min;
   uint32_t rack_rtt;
   uint64_t rack_time_sent;
   uint32_t rack_next_seq;
@@ -586,6 +596,9 @@ udx_interface_event_stop (udx_interface_event_t *handle);
 
 int
 udx_interface_event_close (udx_interface_event_t *handle);
+
+uint32_t
+udx_rtt_min (udx_stream_t *stream);
 
 #ifdef __cplusplus
 }

--- a/src/udx_rate.c
+++ b/src/udx_rate.c
@@ -92,9 +92,9 @@ udx__rate_gen (udx_stream_t *stream, uint32_t delivered, uint32_t lost, udx_rate
     "UDX_CA_LOSS",
   };
 
-  if (rs->interval_ms < stream->rack_rtt_min) {
+  if (rs->interval_ms < udx_rtt_min(stream)) {
     if (!rs->is_retrans) {
-      debug_printf("rs->interval_ms=%ld, rs->delivered=%d, stream->ca_state=%s, stream->min_rtt=%u", rs->interval_ms, rs->delivered, ca_state_string[stream->ca_state], stream->rack_rtt_min);
+      debug_printf("rs->interval_ms=%ld, rs->delivered=%d, stream->ca_state=%s, stream->min_rtt=%u", rs->interval_ms, rs->delivered, ca_state_string[stream->ca_state], udx_rtt_min(stream));
     }
     rs->interval_ms = -1;
     return;

--- a/src/win_filter.c
+++ b/src/win_filter.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2017, Google Inc.
+ *
+ * Use of this source code is governed by the following BSD-style license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * lib/minmax.c: windowed min/max tracker
+ *
+ * Kathleen Nichols' algorithm for tracking the minimum (or maximum)
+ * value of a data stream over some fixed time interval.  (E.g.,
+ * the minimum RTT over the past five minutes.) It uses constant
+ * space and constant time per update yet almost always delivers
+ * the same minimum as an implementation that has to keep all the
+ * data in the window.
+ *
+ * The algorithm keeps track of the best, 2nd best & 3rd best min
+ * values, maintaining an invariant that the measurement time of
+ * the n'th best >= n-1'th best. It also makes sure that the three
+ * values are widely separated in the time window since that bounds
+ * the worse case error when that data is monotonically increasing
+ * over the window.
+ *
+ * Upon getting a new min, we can forget everything earlier because
+ * it has no value - the new min is <= everything else in the window
+ * by definition and it's the most recent. So we restart fresh on
+ * every new min and overwrites 2nd & 3rd choices. The same property
+ * holds for 2nd & 3rd best.
+ *
+ */
+
+#include "win_filter.h"
+
+static uint32_t
+win_filter_apply_common (win_filter_t *wf, uint32_t win, uint64_t t, uint32_t v) {
+  uint32_t dt = t - wf->entries[0].t;
+
+  win_filter_entry_t new = {.t = t, .v = v};
+
+  if (dt > win) {
+    // we've passed the window so bump off entries[0]
+    wf->entries[0] = wf->entries[1];
+    wf->entries[1] = wf->entries[2];
+    wf->entries[2] = new;
+    if (t - wf->entries[0].t > win) {
+      // bump off entries[1] too
+      wf->entries[0] = wf->entries[1];
+      wf->entries[1] = wf->entries[2];
+      wf->entries[2] = new;
+    }
+  } else if (wf->entries[1].t == wf->entries[0].t && dt > win / 4) {
+    wf->entries[2] = new;
+    wf->entries[1] = new;
+  } else if (wf->entries[2].t == wf->entries[1].t && dt > win / 2) {
+    wf->entries[2] = new;
+  }
+
+  return wf->entries[0].v;
+}
+
+uint32_t
+win_filter_reset (win_filter_t *wf, uint64_t t, uint32_t v) {
+  win_filter_entry_t val = {.t = t, .v = v};
+
+  wf->entries[2] = wf->entries[1] = wf->entries[0] = val;
+  return wf->entries[0].v;
+}
+
+uint32_t
+win_filter_apply_max (win_filter_t *wf, uint32_t win, uint64_t t, uint32_t v) {
+  //  new maximum           || nothing in window
+  if (v >= wf->entries[0].v || t - wf->entries[2].t > win) {
+    return win_filter_reset(wf, t, v);
+  }
+
+  win_filter_entry_t new = {.t = t, .v = v};
+
+  if (v >= wf->entries[1].v) {
+    // bigger than our 2nd best
+    wf->entries[2] = new;
+    wf->entries[1] = new;
+  } else if (v >= wf->entries[2].v) {
+    // bigger than our 3rd best
+    wf->entries[2] = new;
+  }
+
+  return win_filter_apply_common(wf, win, t, v);
+}
+
+uint32_t
+win_filter_apply_min (win_filter_t *wf, uint32_t win, uint64_t t, uint32_t v) {
+  //   new minimum           || nothing in window
+  if (v <= wf->entries[0].v || t - wf->entries[2].t > win) {
+    return win_filter_reset(wf, t, v);
+  }
+
+  win_filter_entry_t new = {.t = t, .v = v};
+
+  if (v <= wf->entries[1].v) {
+    // smaller than our 2nd best
+    wf->entries[2] = new;
+    wf->entries[1] = new;
+
+  } else if (v <= wf->entries[2].v) {
+    // smaller than our 3rd best
+    wf->entries[2] = new;
+  }
+  return win_filter_apply_common(wf, win, t, v);
+}

--- a/src/win_filter.h
+++ b/src/win_filter.h
@@ -1,0 +1,19 @@
+
+#ifndef UDX_WINDOWED_FILTER
+#define UDX_WINDOWED_FILTER
+#include "../include/udx.h"
+#include <stdint.h>
+
+static inline uint32_t
+win_filter_get (win_filter_t *wf) {
+  return wf->entries[0].v;
+}
+
+uint32_t
+win_filter_reset (win_filter_t *wf, uint64_t t, uint32_t value);
+uint32_t
+win_filter_apply_min (win_filter_t *wf, uint32_t win, uint64_t t, uint32_t v);
+uint32_t
+win_filter_apply_max (win_filter_t *wf, uint32_t win, uint64_t t, uint32_t v);
+
+#endif // UDX_WINDOWED_FILTER

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ list(APPEND tests
   stream-change-remote
   stream-multiple
   stream-write-read-receive-window
+    win-filter
 )
 
 list(APPEND skipped_tests

--- a/test/win-filter.c
+++ b/test/win-filter.c
@@ -1,0 +1,67 @@
+
+#include "../include/udx.h"
+#include "../src/win_filter.h"
+#include <assert.h>
+
+int
+main () {
+  win_filter_t min_filter;
+  win_filter_t max_filter;
+
+  uint32_t win_ms = 300 * 1000;
+  uint64_t now_ms = 0;
+
+  win_filter_reset(&min_filter, now_ms, ~0U);
+  win_filter_reset(&max_filter, now_ms, 0);
+
+  uint32_t rtt = 0;
+  uint64_t t = now_ms;
+
+  // monotonically increasing rtt
+  for (; t < win_ms; t++, rtt++) {
+    win_filter_apply_min(&min_filter, win_ms, t, rtt);
+    win_filter_apply_max(&max_filter, win_ms, t, rtt);
+  }
+
+  printf("min=%u max=%u\n", win_filter_get(&min_filter), win_filter_get(&max_filter));
+
+  assert(win_filter_get(&min_filter) == 0);
+  assert(win_filter_get(&max_filter) == 300 * 1000 - 1); // -1 because stopped before we actually reach win_ms
+
+  // now add one more, reaching the min filter
+
+  win_filter_apply_min(&min_filter, win_ms, t, rtt);
+  win_filter_apply_max(&max_filter, win_ms, t, rtt);
+
+  assert(win_filter_get(&min_filter) == 0);
+  assert(win_filter_get(&max_filter) == 300 * 1000);
+
+  printf("min=%u max=%u\n", win_filter_get(&min_filter), win_filter_get(&max_filter));
+
+  // and one more, bumping off the min_filter
+  t++;
+  rtt++;
+  win_filter_apply_min(&min_filter, win_ms, t, rtt);
+  win_filter_apply_max(&max_filter, win_ms, t, rtt);
+
+  assert(win_filter_get(&min_filter) == 75001);
+  assert(win_filter_get(&max_filter) == 300 * 1000 + 1);
+
+  printf("min=%u max=%u\n", win_filter_get(&min_filter), win_filter_get(&max_filter));
+
+  // stop monotonically increasing, add a new realistic '14ms' sample
+  // add it 3 times for good measure..
+
+  t++;
+  win_filter_apply_min(&min_filter, win_ms, t, 14);
+  win_filter_apply_max(&min_filter, win_ms, t, 14);
+
+  t++;
+  win_filter_apply_min(&min_filter, win_ms, t, 14);
+  win_filter_apply_max(&min_filter, win_ms, t, 14);
+
+  assert(win_filter_get(&min_filter) == 14);
+  assert(win_filter_get(&max_filter) == 300 * 1000 + 1);
+
+  return 0;
+}


### PR DESCRIPTION
Adds a windowed filter for rtt-min, so instead of tracking a minimum rtt over the lifetime of the connection, minimum-rtt is only remembered for the last 300 seconds. This is recommended by RACK:

> 
> Step 1: Update RACK.min_RTT.
> 
> Use the RTT measurements obtained via [[RFC6298](https://datatracker.ietf.org/doc/html/rfc6298)] or [[RFC7323](https://datatracker.ietf.org/doc/html/rfc7323)] to update the estimated minimum RTT in RACK.min_RTT. **The sender SHOULD track a windowed min-filtered estimate of recent RTT measurements that can adapt when migrating to significantly longer paths rather than tracking a simple global minimum of all RTT measurements.**

The windowed filter is based on the win_minmax implementation from Linux, which happens to be available under a BSD license here: https://groups.google.com/g/bbr-dev/c/3RTgkzi5ZD8 , the only significant change is that we use 64 bit timestamps to keep our own code simple. 

This is a prelude to the BBR patch, where it's also used to track a windowed max bandwidth.

