### PR TITLE
Feature/debug throughput

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ if(WIN32)
   target_compile_options(udx PRIVATE /W4)
 endif()
 
+if (UDX_DEBUG_THROUGHPUT)
+  target_compile_definitions( udx INTERFACE UDX_DEBUG_THROUGHPUT=1 PRIVATE UDX_DEBUG_THROUGHPUT=1 )
+endif()
+
 target_sources(
   udx
   INTERFACE

--- a/docs/debug_throughput/README.md
+++ b/docs/debug_throughput/README.md
@@ -1,0 +1,22 @@
+# debugging throughput
+
+to assist in debugging throughput libudx may be built with `-DUDX_DEBUG_THROUGHPUT`:
+
+```
+bare-make generate --debug -D CMAKE_C_FLAGS='-DUDX_DEBUG_THROUGHPUT'
+bare-make build
+bare-make install # if you need the libraries in ./prebuilds
+```
+
+This will create a `stream.%d.dat` for each stream, where %d is substituted with the stream's local id. The file is formatted as newline separated
+records of the format `<timestamp_ms> <record-type> [<args> ...]`. The main record type is `tp` (throughput) and it looks like `297040999 tp 105503 105092`,
+where the first arg is the first sequence number and the second arg is the current remote_acked number. Other records may simply be `<timestamp> <event>` to
+record a specific event (e.g. a state transition, such as from the startup phase to the bandwidth probe phase. The `tp` records and other records can be used
+to generate sequence-number "Stevens" graphs annotated with arbitrary events with the provided 'stevens.py' script:
+
+```
+./stevens.py stream.1.dat
+```
+
+Any lines in the file that start with the `#` character are considered comments and are skipped.
+

--- a/docs/debug_throughput/README.md
+++ b/docs/debug_throughput/README.md
@@ -1,6 +1,6 @@
 # debugging throughput
 
-to assist in debugging throughput libudx may be built with `-DUDX_DEBUG_THROUGHPUT`:
+To assist in debugging throughput libudx may be built with `-DUDX_DEBUG_THROUGHPUT`:
 
 ```
 bare-make generate --debug -D CMAKE_C_FLAGS='-DUDX_DEBUG_THROUGHPUT'
@@ -8,11 +8,7 @@ bare-make build
 bare-make install # if you need the libraries in ./prebuilds
 ```
 
-This will create a `stream.%d.dat` for each stream, where %d is substituted with the stream's local id. The file is formatted as newline separated
-records of the format `<timestamp_ms> <record-type> [<args> ...]`. The main record type is `tp` (throughput) and it looks like `297040999 tp 105503 105092`,
-where the first arg is the first sequence number and the second arg is the current remote_acked number. Other records may simply be `<timestamp> <event>` to
-record a specific event (e.g. a state transition, such as from the startup phase to the bandwidth probe phase. The `tp` records and other records can be used
-to generate sequence-number "Stevens" graphs annotated with arbitrary events with the provided 'stevens.py' script:
+This will create a `stream.%d.dat` for each stream, where %d is substituted with the stream's local id. The file is formatted as newline-separated records of the format `<timestamp_ms> <record-type> [<args> ...]`. The main record type is `tp` (throughput) and it looks like `297040999 tp 105503 105092`, where the first arg is the first sequence number and the second arg is the current remote_acked number. Other records may simply be `<timestamp> <event>` to record a specific event (e.g. a state transition, such as from the startup phase to the bandwidth probe phase). The `tp` records and other records can be used to generate sequence-number "Stevens" graphs annotated with arbitrary events with the provided 'stevens.py' script:
 
 ```
 ./stevens.py stream.1.dat

--- a/docs/debug_throughput/stevens.py
+++ b/docs/debug_throughput/stevens.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+import matplotlib.pyplot as plot
+import numpy
+import sys
+
+# edit this to skip any records you don't want to graph
+skip_records = ['probe_rtt', 'probe_rtt_done', 'probe_bw', 'drain']
+
+# don't edit these
+
+
+time = []
+sent = []
+acked = []
+
+vlines = []
+
+
+def processFile(path_to_file):
+    prev_time = None
+    t0 = None
+    
+    with open(path_to_file, 'r') as f:
+        for line in f:
+            args = line.split()
+
+            if line.startswith("#"):
+                continue;
+            if len(args) < 2:
+                continue
+
+            t = int(args[0])
+
+            if t0 == None or t < t0:
+                t0 = t
+
+            if args[1] in skip_records:
+                continue
+
+            if args[1] == "tp":
+                s = int(args[2])
+                a = int(args[3])
+
+                #if t != prev_time: # aggregate same times, the last entry will have most up to date
+                time.append(t - t0)
+                sent.append(s)
+                acked.append(a)
+                    #prev_time = t
+            else:
+                # for now, all non-tp args get a vertical line marker
+                vlines.append((t-t0, args[1]))
+
+    print("processed %d records\n" % len(time))
+
+
+if (len(sys.argv) < 2):
+    print("usage: ./stevens.py stream1.dat")
+    exit(1)
+
+
+processFile(sys.argv[1])
+
+print("time entries: %d" % len(time))
+print("vlines=", vlines)
+
+t0 = time[0]
+
+time = [ e - t0 for e in time ]
+
+figure, axes = plot.subplots()
+
+red = "tab:red"
+blue = "tab:blue"
+
+axes.set_xlabel('time (ms)')
+axes.set_ylabel('sent', color=blue)
+
+axes.plot(time, sent, color=blue, label="sent")
+
+d = axes.twinx()
+d.set_ylabel('delivered', color=red)
+d.plot(time, acked, color=red, label="acked")
+
+
+colors = 'bgrcmk'
+color_index=0
+
+for (x, label) in vlines:
+    print("x=", x, "label=", label)
+    plot.axvline(x=x, color=colors[color_index], ls="--", label=label)
+    color_index = color_index + 1 % len(colors)
+
+axes.legend()
+d.legend()
+
+figure.tight_layout()
+
+
+plot.show()

--- a/include/udx.h
+++ b/include/udx.h
@@ -1,8 +1,6 @@
 #ifndef UDX_H
 #define UDX_H
 
-#define DEBUG_THROUGHPUT 1
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -374,7 +372,7 @@ struct udx_stream_s {
   uint64_t packets_rx;
   uint64_t packets_tx;
 
-#ifdef DEBUG_THROUGHPUT
+#ifdef UDX_DEBUG_THROUGHPUT
   FILE *throughput_fd;
 #endif
 };

--- a/include/udx.h
+++ b/include/udx.h
@@ -1,6 +1,8 @@
 #ifndef UDX_H
 #define UDX_H
 
+#define DEBUG_THROUGHPUT 1
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -371,6 +373,10 @@ struct udx_stream_s {
 
   uint64_t packets_rx;
   uint64_t packets_tx;
+
+#ifdef DEBUG_THROUGHPUT
+  FILE *throughput_fd;
+#endif
 };
 
 struct udx_packet_s {

--- a/src/debug.h
+++ b/src/debug.h
@@ -48,6 +48,11 @@ debug_throughput (udx_stream_t *stream) {
   fprintf(stream->throughput_fd, "%" PRIu64 " tp %u %u\n", uv_now(stream->udx->loop), stream->seq, stream->remote_acked);
 }
 
+static inline void
+debug_throughput_init (udx_stream_t *stream) {
+  stream->throughput_fd = NULL;
+}
+
 #include <stdarg.h>
 // prints with format
 // <timestamp> <formatted_string>
@@ -73,6 +78,12 @@ debug_throughput_printf (udx_stream_t *stream, char *fmt, ...) {
   (void) stream;
   (void) fmt;
 }
+
+static inline void
+debug_throughput_init (udx_stream_t *stream) {
+  (void) stream;
+}
+
 #endif
 
 #define debug_printf(...) \

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,8 +1,6 @@
 #ifndef UDX_DEBUG_H
 #define UDX_DEBUG_H
 
-#define DEBUG_THROUGHPUT 1
-
 #ifndef NDEBUG
 #define DEBUG 1
 #else
@@ -18,35 +16,62 @@
 
 static uint64_t debug_start = 0;
 
-static void
+static inline void
 debug_print_cwnd_stats (udx_stream_t *stream) {
   if (!debug_start) debug_start = uv_hrtime() / 1000000;
   printf("%llu %u %u %u\n", (uv_hrtime() / 1000000) - debug_start, stream->cwnd, stream->cwnd_cnt, stream->srtt);
 }
 #else
-static void
+static inline void
 debug_print_cwnd_stats (udx_stream_t *stream) {
   (void) stream; // silence 'unused-parameter' warning
 }
 #endif
 
-#ifdef DEBUG_THROUGHPUT
+#ifdef UDX_DEBUG_THROUGHPUT
 
-static void
-debug_throughput (udx_stream_t *stream) {
-
+static inline void
+open_throughput_file (udx_stream_t *stream) {
   if (!stream->throughput_fd) {
     char filename[100];
     snprintf(filename, sizeof(filename), "stream.%d.dat", stream->local_id);
     stream->throughput_fd = fopen(filename, "w");
   }
+}
 
-  fprintf(stream->throughput_fd, "%" PRIu64 " %u %u\n", uv_now(stream->udx->loop), stream->seq, stream->remote_acked);
+// prints a throughput record. tp = throughput
+// <timestamp> tp <seq> <acked>
+static inline void
+debug_throughput (udx_stream_t *stream) {
+  open_throughput_file(stream);
+
+  fprintf(stream->throughput_fd, "%" PRIu64 " tp %u %u\n", uv_now(stream->udx->loop), stream->seq, stream->remote_acked);
+}
+
+#include <stdarg.h>
+// prints with format
+// <timestamp> <formatted_string>
+static inline void
+debug_throughput_printf (udx_stream_t *stream, char *fmt, ...) {
+  open_throughput_file(stream);
+
+  va_list ap;
+  va_start(ap, fmt);
+  fprintf(stream->throughput_fd, "%" PRIu64 " ", uv_now(stream->udx->loop));
+  vfprintf(stream->throughput_fd, fmt, ap);
+  fprintf(stream->throughput_fd, "\n");
+  va_end(ap);
 }
 #else
-static void
+static inline void
 debug_throughput (udx_stream_t *stream) {
   (void) stream;
+}
+
+static inline void
+debug_throughput_printf (udx_stream_t *stream, char *fmt, ...) {
+  (void) stream;
+  (void) fmt;
 }
 #endif
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,6 +1,8 @@
 #ifndef UDX_DEBUG_H
 #define UDX_DEBUG_H
 
+#define DEBUG_THROUGHPUT 1
+
 #ifndef NDEBUG
 #define DEBUG 1
 #else
@@ -25,6 +27,26 @@ debug_print_cwnd_stats (udx_stream_t *stream) {
 static void
 debug_print_cwnd_stats (udx_stream_t *stream) {
   (void) stream; // silence 'unused-parameter' warning
+}
+#endif
+
+#ifdef DEBUG_THROUGHPUT
+
+static void
+debug_throughput (udx_stream_t *stream) {
+
+  if (!stream->throughput_fd) {
+    char filename[100];
+    snprintf(filename, sizeof(filename), "stream.%d.dat", stream->local_id);
+    stream->throughput_fd = fopen(filename, "w");
+  }
+
+  fprintf(stream->throughput_fd, "%" PRIu64 " %u %u\n", uv_now(stream->udx->loop), stream->seq, stream->remote_acked);
+}
+#else
+static void
+debug_throughput (udx_stream_t *stream) {
+  (void) stream;
 }
 #endif
 

--- a/src/udx.c
+++ b/src/udx.c
@@ -2346,6 +2346,8 @@ udx_stream_init (udx_t *udx, udx_stream_t *stream, uint32_t local_id, udx_stream
   // Add the socket to the active set
   udx__cirbuf_set(&(udx->streams_by_id), (udx_cirbuf_val_t *) stream);
 
+  debug_throughput_init(stream);
+
   return 0;
 }
 

--- a/src/udx_rate.c
+++ b/src/udx_rate.c
@@ -23,6 +23,8 @@ udx__rate_pkt_sent (udx_stream_t *stream, udx_packet_t *pkt) {
   pkt->delivered_ts = stream->delivered_ts;
   pkt->delivered = stream->delivered;
   pkt->is_app_limited = stream->app_limited ? true : false;
+
+  debug_throughput(stream);
 }
 
 static inline uint32_t
@@ -106,6 +108,8 @@ udx__rate_gen (udx_stream_t *stream, uint32_t delivered, uint32_t lost, udx_rate
     stream->rate_interval_ms = rs->interval_ms;
     stream->rate_sample_is_app_limited = rs->is_app_limited;
   }
+
+  debug_throughput(stream);
 }
 
 void


### PR DESCRIPTION
Add a compile-time flag `DEBUG_UDX_THROUGHPUT` to write a per-stream throughput data to a file for plotting. From the additional README:

---

To assist in debugging throughput libudx may be built with `-DUDX_DEBUG_THROUGHPUT`:

```
bare-make generate --debug -D CMAKE_C_FLAGS='-DUDX_DEBUG_THROUGHPUT'
bare-make build
bare-make install # if you need the libraries in ./prebuilds
```

This will create a `stream.%d.dat` for each stream, where %d is substituted with the stream's local id. The file is formatted as newline-separated records of the format `<timestamp_ms> <record-type> [<args> ...]`. The main record type is `tp` (throughput) and it looks like `297040999 tp 105503 105092`, where the first arg is the first sequence number and the second arg is the current remote_acked number. Other records may simply be `<timestamp> <event>` to record a specific event (e.g. a state transition, such as from the startup phase to the bandwidth probe phase). The `tp` records and other records can be used to generate sequence-number "Stevens" graphs annotated with arbitrary events with the provided 'stevens.py' script:

```
./stevens.py stream.1.dat
```

Any lines in the file that start with the `#` character are considered comments and are skipped.