### PR TITLE
Refactor timers

### DIFF
--- a/include/udx.h
+++ b/include/udx.h
@@ -215,6 +215,15 @@ struct udx_socket_s {
 #define UDX_CA_RECOVERY 2
 #define UDX_CA_LOSS     3
 
+typedef enum {
+  UDX_TIMER_NONE,
+  UDX_TIMER_RTO,
+  UDX_TIMER_RACK_REO,
+  UDX_TIMER_TLP,
+  UDX_TIMER_ZWP,
+  UDX_TIMER_KEEPALIVE
+} udx_stream_timer_type_t;
+
 struct udx_stream_s {
   uint32_t local_id; // must be first entry, so its compat with the cirbuf
   uint32_t remote_id;
@@ -292,6 +301,8 @@ struct udx_stream_s {
   uint32_t rate_interval_ms;       // saved rate sample: time elapsed
   bool rate_sample_is_app_limited; // saved rate sample: app limited?
 
+  udx_stream_timer_type_t pending_timer;
+  uint64_t next_rto_ts; // todo: remove this, calculate from oldest packet (head) in rtx queue
   uint32_t srtt;
   uint32_t rttvar;
   uint32_t rto;
@@ -359,12 +370,8 @@ struct udx_stream_s {
   bool tlp_permitted;   // if set, srtt has been updated since the last tlp
   uint32_t tlp_end_seq; // seq at time of tlp sent. invalid if tlp_inflight is not set
 
-  // optimize: use one timer and a action (RTO, RACK_REO, TLP) variable
-  int nrefs;
-  uv_timer_t rto_timer;
-  uv_timer_t rack_reo_timer;
-  uv_timer_t tlp_and_keepalive_timer;
-  uv_timer_t zwp_timer;
+  int nrefs;        // # of libuv handles open (2 timer, 1 prepare)
+  uv_timer_t timer; // RTO, RACK_REO,TLP, ZWP and keepalive timer. stream.pending_timer tells which is currently set (if any)
   uv_timer_t refill_pacing_timer;
 
   size_t inflight;

--- a/src/udx.c
+++ b/src/udx.c
@@ -362,6 +362,44 @@ finalize_maybe (uv_handle_t *timer) {
   ref_dec(udx);
 }
 
+static void
+udx_rto_timeout (uv_timer_t *handle);
+static void
+udx_rack_reo_timeout (uv_timer_t *timer);
+static void
+udx_tlp_timeout (uv_timer_t *timer);
+static void
+udx_zwp_timeout (uv_timer_t *timer);
+static void
+udx_keepalive_timeout (uv_timer_t *timer);
+
+static void
+stream_timer_start (udx_stream_t *stream, udx_stream_timer_type_t timer, uint32_t time_wait_ms) {
+  // todo: see if we can get this from uv_timer_get_due_in in stream_timer_start
+  // if (stream->pending_timer == UDX_TIMER_RTO && (timer == UDX_TIMER_RACK_REO || timer == UDX_TIMER_TLP)
+  //   stream->next_rto_ts = uv_now(stream->udx->loop) + uv_timer_get_due_in(&stream->timer);
+  // }
+
+  stream->pending_timer = timer;
+
+  uv_timer_cb timer_to_callback[] = {
+    NULL,
+    udx_rto_timeout,
+    udx_rack_reo_timeout,
+    udx_tlp_timeout,
+    udx_zwp_timeout,
+    udx_keepalive_timeout
+  };
+
+  uv_timer_start(&stream->timer, timer_to_callback[timer], time_wait_ms, 0);
+}
+
+static void
+stream_timer_stop (udx_stream_t *stream) {
+  uv_timer_stop(&stream->timer);
+  stream->pending_timer = UDX_TIMER_NONE;
+}
+
 // close stream immediately.
 // 1. if you call this on the receive path (process_packet)
 // you must immediately return and process another packet
@@ -423,16 +461,10 @@ close_stream (udx_stream_t *stream, int err) {
   udx__cirbuf_destroy(&stream->incoming);
   udx__cirbuf_destroy(&stream->outgoing);
 
-  uv_timer_stop(&stream->rto_timer);
-  uv_timer_stop(&stream->rack_reo_timer);
-  uv_timer_stop(&stream->tlp_and_keepalive_timer);
-  uv_timer_stop(&stream->zwp_timer);
+  uv_timer_stop(&stream->timer);
   uv_timer_stop(&stream->refill_pacing_timer);
 
-  uv_close((uv_handle_t *) &stream->rto_timer, finalize_maybe);
-  uv_close((uv_handle_t *) &stream->rack_reo_timer, finalize_maybe);
-  uv_close((uv_handle_t *) &stream->tlp_and_keepalive_timer, finalize_maybe);
-  uv_close((uv_handle_t *) &stream->zwp_timer, finalize_maybe);
+  uv_close((uv_handle_t *) &stream->timer, finalize_maybe);
   uv_close((uv_handle_t *) &stream->refill_pacing_timer, finalize_maybe);
   uv_close((uv_handle_t *) &stream->pending_packet_prepare, finalize_maybe);
 
@@ -442,9 +474,6 @@ close_stream (udx_stream_t *stream, int err) {
 
   return 1;
 }
-
-static void
-udx_rto_timeout (uv_timer_t *handle);
 
 static bool
 _maybe_adjust_ttl (udx_socket_t *socket) {
@@ -526,11 +555,8 @@ udx_keepalive_timeout (uv_timer_t *timer) {
 
   send_probe(stream);
 
-  uv_timer_start(&stream->tlp_and_keepalive_timer, udx_keepalive_timeout, stream->keepalive_timeout_ms, 0);
+  stream_timer_start(stream, UDX_TIMER_KEEPALIVE, stream->keepalive_timeout_ms);
 }
-
-static void
-schedule_loss_probe (udx_stream_t *stream);
 
 // rack recovery implemented using https://datatracker.ietf.org/doc/rfc8985/
 
@@ -940,6 +966,29 @@ send_packets (udx_stream_t *stream) {
   }
 }
 
+// if not 'from_now' then we use the saved rto in `stream->next_rto_ts`
+// this is used when the reorder timeout or the tail-loss probe timer is
+// set over top of the normal rto.
+static void
+rearm_rto (udx_stream_t *stream, bool from_now) {
+  if (stream->seq == stream->remote_acked) {
+    stream_timer_stop(stream);
+  } else {
+    uint64_t rto = stream->rto;
+    if (from_now) {
+      stream->next_rto_ts = uv_now(stream->udx->loop) + rto;
+    } else {
+      assert(stream->pending_timer == UDX_TIMER_RACK_REO || stream->pending_timer == UDX_TIMER_TLP);
+      int64_t rto_delta_ms = stream->next_rto_ts - uv_now(stream->udx->loop);
+      if (rto_delta_ms < 0) {
+        rto_delta_ms = 1;
+      }
+      rto = rto_delta_ms;
+    }
+    uv_timer_start(&stream->timer, udx_rto_timeout, rto, 0);
+  }
+}
+
 static void
 udx_tlp_timeout (uv_timer_t *timer) {
   // rack 7.3
@@ -952,7 +1001,7 @@ udx_tlp_timeout (uv_timer_t *timer) {
   }
 
   if (stream->tlp_in_flight || !stream->tlp_permitted) {
-    schedule_loss_probe(stream);
+    rearm_rto(stream, false);
     return;
   }
 
@@ -960,12 +1009,12 @@ udx_tlp_timeout (uv_timer_t *timer) {
   if (!send_new_packet(stream, UDX_PROBE_TYPE_TLP)) {
     udx_packet_t *pkt = (udx_packet_t *) udx__cirbuf_get(&stream->outgoing, stream->seq - 1);
 
-    if (!pkt || pkt->lost) {
-      schedule_loss_probe(stream);
+    if (!pkt || pkt->lost || pkt->ref_count == 2) {
+      rearm_rto(stream, false);
       return;
     }
 
-    debug_printf("udx: sending tlp from existing packet");
+    debug_printf("udx: making tlp from existing packet seq=%u\n", pkt->seq);
 
     udx__queue_unlink(&stream->inflight_queue, &pkt->queue); // retransmit will add it back
     retransmit_packet(stream, pkt);
@@ -975,29 +1024,44 @@ udx_tlp_timeout (uv_timer_t *timer) {
     stream->tlp_end_seq = pkt->seq;
     stream->tlp_permitted = false;
   }
+
+  rearm_rto(stream, true);
 }
 
 // schedule or re-schedule TLP. fired on either
 // 1. new data transmission
 // 2. cumulative ack while not in recovery
-static void
-schedule_loss_probe (udx_stream_t *stream) {
+// returns false if we cannot schedule a probe
+static bool
+schedule_loss_probe (udx_stream_t *stream, bool advancing_rto) {
+  if (stream->seq == stream->remote_acked || stream->ca_state != UDX_CA_OPEN) {
+    return false;
+  }
+
   // rack 7.2
-  uint32_t pto = 1000;
+  uint32_t timeout = 1000;
 
   if (stream->srtt) {
-    pto = stream->srtt * 2;
-    if (stream->inflight_queue.len == 1) {
-      pto += UDX_TLP_MAX_ACK_DELAY;
+    timeout = stream->srtt * 2;
+    if ((stream->inflight_queue.len + stream->retransmit_queue.len) == 1) {
+      timeout += UDX_TLP_MAX_ACK_DELAY;
     }
   }
 
-  // clamp pto
-  if (uv_timer_get_due_in(&stream->rto_timer) < pto) {
-    pto = uv_timer_get_due_in(&stream->rto_timer);
+  uint32_t rto_delta_ms = stream->rto;
+
+  if (advancing_rto) {
+    int64_t delta = stream->next_rto_ts - uv_now(stream->udx->loop);
+    if (delta < 0) {
+      delta = 1;
+    }
+    rto_delta_ms = delta;
   }
 
-  uv_timer_start(&stream->tlp_and_keepalive_timer, udx_tlp_timeout, pto, 0);
+  timeout = min_uint32(timeout, rto_delta_ms);
+
+  stream_timer_start(stream, UDX_TIMER_TLP, timeout);
+  return true;
 }
 
 static uint32_t
@@ -1078,20 +1142,29 @@ rack_detect_loss (udx_stream_t *stream) {
   return timeout;
 }
 
-static void
-rack_detect_loss_and_arm_timer (uv_timer_t *timer) {
-  udx_stream_t *stream = timer->data;
+// return true if timer was started
+static bool
+rack_detect_loss_and_arm_timer (udx_stream_t *stream) {
   uint32_t timeout = rack_detect_loss(stream);
 
   if (timeout > 0) {
     assert(!(stream->status & UDX_STREAM_CLOSED));
-    uv_timer_start(&stream->rack_reo_timer, rack_detect_loss_and_arm_timer, timeout, 0);
+    stream_timer_start(stream, UDX_TIMER_RACK_REO, timeout);
+    return true;
   }
+  return false;
+}
+
+static void
+udx_rack_reo_timeout (uv_timer_t *timer) {
+  udx_stream_t *stream = timer->data;
+  rack_detect_loss_and_arm_timer(stream);
 }
 
 static void
 udx_zwp_timeout (uv_timer_t *timer) {
   udx_stream_t *stream = timer->data;
+  stream->pending_timer = UDX_TIMER_NONE;
   assert(stream->status & UDX_STREAM_CONNECTED);
   assert(stream->send_rwnd == 0);
   assert((stream->status & UDX_STREAM_CLOSED) == 0);
@@ -1104,6 +1177,7 @@ udx_zwp_timeout (uv_timer_t *timer) {
 static void
 udx_rto_timeout (uv_timer_t *timer) {
   udx_stream_t *stream = timer->data;
+  stream->pending_timer = UDX_TIMER_NONE;
   assert(stream->status & UDX_STREAM_CONNECTED);
   assert(stream->remote_acked != stream->seq);
 
@@ -1117,7 +1191,8 @@ udx_rto_timeout (uv_timer_t *timer) {
   stream->tlp_is_retrans = false;
 
   assert(!(stream->status & UDX_STREAM_CLOSED));
-  uv_timer_start(&stream->rto_timer, udx_rto_timeout, stream->rto * 2, 0);
+  stream->next_rto_ts = uv_now(stream->udx->loop) + stream->rto * 2;
+  stream_timer_start(stream, UDX_TIMER_RTO, stream->rto * 2);
 
   // zero retransmit queue
   udx__queue_init(&stream->retransmit_queue);
@@ -1166,9 +1241,6 @@ udx_rto_timeout (uv_timer_t *timer) {
   bbr_on_rto(stream);
   send_packets(stream);
 }
-
-static void
-rack_detect_loss_and_arm_timer (uv_timer_t *timer);
 
 // processing packets after waking from suspend may result in
 // spurious RTT values, where the RTT value includes the time spent suspended.
@@ -1552,16 +1624,12 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
   if (seq_compare(ack, stream->remote_acked) >= 0) {
     if (seq_compare(stream->send_wl1, seq) < 0 || (stream->send_wl1 == seq && seq_compare(stream->send_wl2, ack) <= 0)) {
       // update send window
-      if (rwnd > 0) {
-        uv_timer_stop(&stream->zwp_timer);
+      if (rwnd > 0 && stream->pending_timer == UDX_TIMER_ZWP) {
+        stream_timer_stop(stream);
       }
       stream->send_rwnd = rwnd;
       stream->send_wl1 = seq;
       stream->send_wl2 = ack;
-
-      if (rwnd == 0) {
-        uv_timer_start(&stream->zwp_timer, udx_zwp_timeout, stream->rto, 0);
-      }
     }
   }
 
@@ -1605,18 +1673,16 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
     stream->remote_acked = ack;
   }
 
-  if (ended) {
+  if (ended) { // remote acked our end
     if (stream->status & UDX_STREAM_DEAD) {
       return 1;
     }
 
     if (stream->remote_acked == stream->seq) {
-      uv_timer_stop(&stream->rto_timer);
-
       if (stream->keepalive_timeout_ms) {
-        uv_timer_start(&stream->tlp_and_keepalive_timer, udx_keepalive_timeout, stream->keepalive_timeout_ms, 0);
+        stream_timer_start(stream, UDX_TIMER_KEEPALIVE, stream->keepalive_timeout_ms);
       } else {
-        uv_timer_stop(&stream->tlp_and_keepalive_timer);
+        stream_timer_stop(stream);
       }
     }
 
@@ -1653,30 +1719,34 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
   delivered = stream->delivered - delivered;
   lost = stream->lost - lost;
 
-  if (ack_advanced) {
-    // rack 7.2
-    if (stream->ca_state == UDX_CA_OPEN && !stream->sacks) {
-      schedule_loss_probe(stream);
-    }
-  }
+  bool arm_rto_or_tlp = ack_advanced && data_inflight;
 
   if (delivered > 0) {
     if (stream->remote_acked == stream->seq) {
+      arm_rto_or_tlp = false;
       assert(stream->inflight_queue.len == 0 && stream->retransmit_queue.len == 0);
-      uv_timer_stop(&stream->rto_timer);
 
-      if (stream->keepalive_timeout_ms) {
-        uv_timer_start(&stream->tlp_and_keepalive_timer, udx_keepalive_timeout, stream->keepalive_timeout_ms, 0);
+      if (stream->send_rwnd == 0 && stream->writes_queued_bytes > 0) {
+        stream_timer_start(stream, UDX_TIMER_ZWP, stream->rto);
+      } else if (stream->keepalive_timeout_ms) {
+        stream_timer_start(stream, UDX_TIMER_KEEPALIVE, stream->keepalive_timeout_ms);
       } else {
-        uv_timer_stop(&stream->tlp_and_keepalive_timer);
+        stream_timer_stop(stream);
       }
     } else {
-      assert(!(stream->status & UDX_STREAM_CLOSED));
-      uv_timer_start(&stream->rto_timer, udx_rto_timeout, stream->rto, 0);
+      stream->next_rto_ts = uv_now(stream->udx->loop) + stream->rto;
     }
 
     // rack 6.2.5
-    rack_detect_loss_and_arm_timer(&stream->rack_reo_timer);
+    if (rack_detect_loss_and_arm_timer(stream)) {
+      arm_rto_or_tlp = false;
+    }
+  }
+
+  if (arm_rto_or_tlp) {
+    if (!schedule_loss_probe(stream, true)) {
+      rearm_rto(stream, true);
+    }
   }
 
   if (type & UDX_HEADER_DATA_OR_END) {
@@ -1734,33 +1804,25 @@ pacing_timer_timeout (uv_timer_t *timer) {
   send_packets(stream);
 }
 
-// arms the retransmit timers (RTO, TLP, ZWP), called after data is transmitted
+// arms the retransmit timers (RTO, TLP), called after data is transmitted
 // or retransmitted.
 static void
 arm_stream_timers (udx_stream_t *stream, bool sent_tlp) {
   assert(stream->inflight_queue.len > 0);
   assert(stream->remote_acked != stream->seq);
+  assert(stream->rto > 0);
+  assert(stream->status != UDX_STREAM_CLOSED);
 
-  if (!uv_is_active((uv_handle_t *) &stream->rto_timer)) {
-    assert(stream->rto >= 1);
-    assert(stream->status != UDX_STREAM_CLOSED);
-    uv_timer_start(&stream->rto_timer, udx_rto_timeout, stream->rto, 0);
+  stream->next_rto_ts = uv_now(stream->udx->loop) + stream->rto;
+
+  if (!uv_is_active((uv_handle_t *) &stream->timer) || (stream->pending_timer == UDX_TIMER_ZWP || stream->pending_timer == UDX_TIMER_KEEPALIVE || stream->pending_timer == UDX_TIMER_TLP)) {
+    stream_timer_start(stream, UDX_TIMER_RTO, stream->rto);
   }
 
   // rack 7.2 rearm tlp timer
 
-  if (stream->ca_state != UDX_CA_OPEN || stream->sacks) {
-    uv_timer_stop(&stream->tlp_and_keepalive_timer);
-  } else {
-    if (!sent_tlp) {
-      schedule_loss_probe(stream);
-    }
-  }
-
-  if (stream->send_rwnd == 0) {
-    uv_timer_start(&stream->zwp_timer, udx_zwp_timeout, stream->rto, 0);
-  } else {
-    uv_timer_stop(&stream->zwp_timer);
+  if (stream->ca_state == UDX_CA_OPEN && !stream->sacks && !sent_tlp) {
+    schedule_loss_probe(stream, false);
   }
 }
 
@@ -2184,8 +2246,8 @@ udx_stream_init (udx_t *udx, udx_stream_t *stream, uint32_t local_id, udx_stream
 
   stream->rto = 1000;
 
-  uv_timer_init(udx->loop, &stream->rto_timer);
-  stream->rto_timer.data = stream;
+  uv_timer_init(udx->loop, &stream->timer);
+  stream->timer.data = stream;
 
   win_filter_reset(&stream->rtt_min, uv_now(udx->loop), ~0U);
 
@@ -2195,19 +2257,10 @@ udx_stream_init (udx_t *udx, udx_stream_t *stream, uint32_t local_id, udx_stream
   uv_prepare_init(udx->loop, &stream->pending_packet_prepare);
   stream->pending_packet_prepare.data = stream;
 
-  uv_timer_init(udx->loop, &stream->rack_reo_timer);
-  stream->rack_reo_timer.data = stream;
-
-  uv_timer_init(udx->loop, &stream->tlp_and_keepalive_timer);
-  stream->tlp_and_keepalive_timer.data = stream;
-
-  uv_timer_init(udx->loop, &stream->zwp_timer);
-  stream->zwp_timer.data = stream;
-
   uv_timer_init(udx->loop, &stream->refill_pacing_timer);
   stream->refill_pacing_timer.data = stream;
 
-  stream->nrefs = 6; // rack_reo_timer, tlp_timer, zwp_timer, refill_pacing_timer, rto_timer, pending_packet_prepare
+  stream->nrefs = 3; // timer, refill_pacing_timer, pending_packet_prepare
 
   udx__queue_init(&stream->inflight_queue);
   udx__queue_init(&stream->retransmit_queue);
@@ -2265,7 +2318,7 @@ udx_stream_set_keepalive (udx_stream_t *stream, uint32_t keepalive_timeout_ms) {
   stream->keepalive_timeout_ms = keepalive_timeout_ms;
 
   if (stream->remote_acked == stream->seq && keepalive_timeout_ms && stream->status & UDX_STREAM_CONNECTED) {
-    uv_timer_start(&stream->tlp_and_keepalive_timer, udx_keepalive_timeout, stream->keepalive_timeout_ms, 0);
+    stream_timer_start(stream, UDX_TIMER_KEEPALIVE, stream->keepalive_timeout_ms);
   }
 
   return 0;
@@ -2471,7 +2524,7 @@ udx_stream_connect (udx_stream_t *stream, udx_socket_t *socket, uint32_t remote_
   }
 
   if (stream->keepalive_timeout_ms) {
-    uv_timer_start(&stream->tlp_and_keepalive_timer, udx_keepalive_timeout, stream->keepalive_timeout_ms, 0);
+    stream_timer_start(stream, UDX_TIMER_KEEPALIVE, stream->keepalive_timeout_ms);
   }
 
   return 0;

--- a/src/udx.c
+++ b/src/udx.c
@@ -1479,7 +1479,6 @@ detect_loss_repaired_by_loss_probe (udx_stream_t *stream, uint32_t ack) {
     if (!stream->tlp_is_retrans) {
       stream->tlp_in_flight = false;
     } else if (seq_compare(ack, stream->tlp_end_seq) > 0) {
-      debug_printf("tlp: loss probe retransmission masked lost packet, invoking congestion control\n");
       stream->tlp_in_flight = false;
     }
   }

--- a/src/udx.c
+++ b/src/udx.c
@@ -374,14 +374,14 @@ udx_keepalive_timeout (uv_timer_t *timer);
 
 static void
 stream_timer_start (udx_stream_t *stream, udx_stream_timer_type_t timer, uint32_t time_wait_ms) {
-  // todo: see if we can get this from uv_timer_get_due_in in stream_timer_start
-  // if (stream->pending_timer == UDX_TIMER_RTO && (timer == UDX_TIMER_RACK_REO || timer == UDX_TIMER_TLP)
-  //   stream->next_rto_ts = uv_now(stream->udx->loop) + uv_timer_get_due_in(&stream->timer);
-  // }
+  // as a special case, save the next_rto_ts so that it can be restored if necessary
+  if (timer == UDX_TIMER_RTO) {
+    stream->next_rto_ts = uv_now(stream->udx->loop) + time_wait_ms;
+  }
 
   stream->pending_timer = timer;
 
-  uv_timer_cb timer_to_callback[] = {
+  static uv_timer_cb timer_to_callback[] = {
     NULL,
     udx_rto_timeout,
     udx_rack_reo_timeout,
@@ -977,18 +977,6 @@ send_packets (udx_stream_t *stream) {
   }
 }
 
-// how many ms into the future should the rto fire
-int64_t
-udx_rto_delta_ms (udx_stream_t *stream) {
-  udx_packet_t *pkt = udx__cirbuf_get(&stream->outgoing, stream->remote_acked);
-  assert(pkt != NULL);
-
-  uint32_t rto = stream->rto;
-  uint64_t rto_ts = pkt->time_sent + rto;
-
-  return rto_ts - uv_now(stream->udx->loop);
-}
-
 // if not 'from_now' then we use the saved rto in `stream->next_rto_ts`
 // this is used when the reorder timeout or the tail-loss probe timer is
 // set over top of the normal rto.
@@ -998,10 +986,7 @@ rearm_rto (udx_stream_t *stream, bool from_now) {
     stream_timer_stop(stream);
   } else {
     uint64_t rto = stream->rto;
-    if (from_now) {
-      stream->next_rto_ts = uv_now(stream->udx->loop) + rto;
-    } else {
-
+    if (!from_now) {
       assert(stream->pending_timer == UDX_TIMER_RACK_REO || stream->pending_timer == UDX_TIMER_TLP);
       int64_t rto_delta_ms = stream->next_rto_ts - uv_now(stream->udx->loop);
       if (rto_delta_ms < 0) {
@@ -1009,7 +994,7 @@ rearm_rto (udx_stream_t *stream, bool from_now) {
       }
       rto = rto_delta_ms;
     }
-    uv_timer_start(&stream->timer, udx_rto_timeout, rto, 0);
+    stream_timer_start(stream, UDX_TIMER_RTO, rto);
   }
 }
 
@@ -1222,7 +1207,6 @@ udx_rto_timeout (uv_timer_t *timer) {
   stream->tlp_is_retrans = false;
 
   assert(!(stream->status & UDX_STREAM_CLOSED));
-  stream->next_rto_ts = uv_now(stream->udx->loop) + stream->rto * 2;
   stream_timer_start(stream, UDX_TIMER_RTO, stream->rto * 2);
 
   // zero retransmit queue
@@ -1863,9 +1847,7 @@ arm_stream_timers (udx_stream_t *stream, bool sent_tlp) {
   assert(stream->rto > 0);
   assert(stream->status != UDX_STREAM_CLOSED);
 
-  stream->next_rto_ts = uv_now(stream->udx->loop) + stream->rto;
-
-  if (stream->pending_timer == UDX_TIMER_NONE || stream->pending_timer == UDX_TIMER_ZWP || stream->pending_timer == UDX_TIMER_KEEPALIVE || stream->pending_timer == UDX_TIMER_TLP) {
+  if (stream->pending_timer == UDX_TIMER_NONE || stream->pending_timer == UDX_TIMER_ZWP || stream->pending_timer == UDX_TIMER_KEEPALIVE) {
     stream_timer_start(stream, UDX_TIMER_RTO, stream->rto);
   }
 

--- a/src/udx.c
+++ b/src/udx.c
@@ -1060,7 +1060,7 @@ schedule_loss_probe (udx_stream_t *stream, bool advancing_rto) {
 
   uint32_t rto_delta_ms = stream->rto;
 
-  if (advancing_rto) {
+  if (!advancing_rto) {
     int64_t delta = stream->next_rto_ts - uv_now(stream->udx->loop);
     if (delta < 0) {
       delta = 1;

--- a/src/udx.c
+++ b/src/udx.c
@@ -381,6 +381,7 @@ stream_timer_start (udx_stream_t *stream, udx_stream_timer_type_t timer, uint32_
 
   stream->pending_timer = timer;
 
+  // important: order must match order in the udx_stream_timer_type_t enum
   static uv_timer_cb timer_to_callback[] = {
     NULL,
     udx_rto_timeout,

--- a/src/udx.c
+++ b/src/udx.c
@@ -1044,7 +1044,7 @@ udx_tlp_timeout (uv_timer_t *timer) {
 // returns false if we cannot schedule a probe
 static bool
 schedule_loss_probe (udx_stream_t *stream, bool advancing_rto) {
-  if (stream->seq == stream->remote_acked || stream->ca_state != UDX_CA_OPEN) {
+  if (stream->seq == stream->remote_acked || stream->ca_state != UDX_CA_OPEN || stream->sacks) {
     return false;
   }
 
@@ -1170,7 +1170,7 @@ udx_rack_reo_timeout (uv_timer_t *timer) {
   udx_stream_t *stream = timer->data;
   rack_detect_loss(stream);
 
-  bool from_now = stream->pending_timer == UDX_TIMER_RACK_REO || stream->pending_timer == UDX_TIMER_TLP;
+  bool from_now = !(stream->pending_timer == UDX_TIMER_RACK_REO || stream->pending_timer == UDX_TIMER_TLP);
 
   if (stream->pending_timer != UDX_TIMER_RTO) {
     rearm_rto(stream, from_now);

--- a/src/udx.c
+++ b/src/udx.c
@@ -54,7 +54,7 @@
 #define UDX_ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 
 static void
-arm_stream_timers (udx_stream_t *stream, bool sent_tlp);
+arm_stream_timers (udx_stream_t *stream, bool arm_tlp);
 
 typedef struct {
   uint32_t seq; // must be the first entry, so its compat with the cirbuf
@@ -861,7 +861,7 @@ _send_new_packet (udx_stream_t *stream, int probe_type) {
     stream->tlp_permitted = false;
   }
 
-  arm_stream_timers(stream, tlp);
+  arm_stream_timers(stream, !tlp); // arm TLP timer unless this packet itself was a TLP
 
   assert(pkt->size > 0 && pkt->size < 1500);
 
@@ -957,7 +957,7 @@ retransmit_packet (udx_stream_t *stream, udx_packet_t *pkt) {
     bbr_on_transmit_start(stream, uv_now(stream->udx->loop));
   }
 
-  arm_stream_timers(stream, false);
+  arm_stream_timers(stream, false); // don't arm TLP on retransmit
   return;
 }
 
@@ -1839,9 +1839,9 @@ pacing_timer_timeout (uv_timer_t *timer) {
 }
 
 // arms the retransmit timers (RTO, TLP), called after data is transmitted
-// or retransmitted.
+// or retransmitted. 'arm_tlp' is set when transmitting new data that is not itself a TLP
 static void
-arm_stream_timers (udx_stream_t *stream, bool sent_tlp) {
+arm_stream_timers (udx_stream_t *stream, bool arm_tlp) {
   assert(stream->inflight_queue.len > 0);
   assert(stream->remote_acked != stream->seq);
   assert(stream->rto > 0);
@@ -1853,7 +1853,7 @@ arm_stream_timers (udx_stream_t *stream, bool sent_tlp) {
 
   // rack 7.2 rearm tlp timer
 
-  if (stream->ca_state == UDX_CA_OPEN && !stream->sacks && !sent_tlp) {
+  if (arm_tlp && stream->ca_state == UDX_CA_OPEN && !stream->sacks) {
     schedule_loss_probe(stream, false);
   }
 }


### PR DESCRIPTION
This PR replaces 5 libuv timers with 1 libuv timer, based on the observation that only one of these timers need to be active at a time:

1. Retransmission timer (RTO)
2. Tail-Loss Probe timer (TLP)
3. Rack-Reorder timer (RACK_REO)
4. Zero-Window probe timer (ZWP)
5. KeepAlive probe timer (KeepAlive)

(4) Zero-Window probe and (5) KeepAlive can only be active if there are no packets in flight, ie all data has been acked. If the window size is zero then the ZWP timer is set instead of KeepAlive

(1) RTO, (2) TLP or (3) RACK_REO may be active when data is in flight.. The TLP is set when no loss is detected and the RACK_REO is set when potential loss (in the form of a SACK) is received, both of these timers reset the RTO timer on expiration.