### PR TITLE
Do not defer cancel_packet() on stream close

### DIFF
--- a/include/udx.h
+++ b/include/udx.h
@@ -405,8 +405,6 @@ struct udx_packet_s {
 
   udx_stream_t *stream; // for incrementing counters when packet is sent
 
-  bool cancelled; // true if the stream was closed while this packet is in the uv_udp_send queue
-                  // immediateyl call on_ack(UV_ECANCELLED) in the callback
   bool lost;
   bool retransmitted;
   uint8_t transmits;

--- a/src/udx.c
+++ b/src/udx.c
@@ -219,9 +219,6 @@ cancel_packet (udx_packet_t *pkt) {
 static void
 deref_packet (udx_packet_t *pkt) {
   if (--pkt->ref_count == 0) {
-    if (pkt->cancelled) {
-      cancel_packet(pkt);
-    }
     if (pkt->bufs != &pkt->buf_sml[0]) {
       free(pkt->bufs);
       free(pkt->wbufs);
@@ -248,7 +245,7 @@ clear_outgoing_packets (udx_stream_t *stream) {
     udx_packet_t *pkt = (udx_packet_t *) udx__cirbuf_remove(&(stream->outgoing), seq);
 
     if (pkt == NULL) continue;
-    pkt->cancelled = true;
+    cancel_packet(pkt);
     deref_packet(pkt);
   }
 


### PR DESCRIPTION
call `cancel_packet()` immediately on stream close instead of waiting for `deref_packet()` to free the packet.