### PR TITLE
Probe streams on connect for passive relays

### DIFF
--- a/src/udx.c
+++ b/src/udx.c
@@ -490,7 +490,7 @@ on_packet_send_slow (uv_udp_send_t *req, int status) {
 }
 
 static void
-send_probe (udx_stream_t *stream) {
+send_probe (udx_stream_t *stream, bool count_stats) {
   if (!stream->socket) {
     return;
   }
@@ -518,10 +518,11 @@ send_probe (udx_stream_t *stream) {
     }
   }
 
+  if (!count_stats) return;
+
   // consider the probe to be sent, even on slow path.
   stream->packets_tx++;
   stream->bytes_tx += buf.len;
-
   stream->socket->packets_tx++;
   stream->socket->bytes_tx += buf.len;
   stream->udx->packets_tx++;
@@ -533,7 +534,7 @@ udx_keepalive_timeout (uv_timer_t *timer) {
   udx_stream_t *stream = timer->data;
   assert(stream->seq == stream->remote_acked);
 
-  send_probe(stream);
+  send_probe(stream, true);
 
   uv_timer_start(&stream->tlp_and_keepalive_timer, udx_keepalive_timeout, stream->keepalive_timeout_ms, 0);
 }
@@ -2523,7 +2524,7 @@ udx_stream_connect (udx_stream_t *stream, udx_socket_t *socket, uint32_t remote_
   }
 
   // Let passive relays learn this endpoint before the first data packet.
-  send_probe(stream);
+  send_probe(stream, false);
 
   return 0;
 }

--- a/src/udx.c
+++ b/src/udx.c
@@ -1478,8 +1478,14 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
   stream->bytes_rx += buf_len;
   stream->packets_rx += 1;
 
+  // Connect probes are sent before application data to let passive relay
+  // streams learn their endpoint address. For regular preconnect streams,
+  // keep the existing contract where the firewall sees the first real packet.
+  bool is_probe = type & UDX_HEADER_HEARTBEAT;
+  bool should_firewall = !is_probe || stream->relay_to != NULL;
+
   // We expect this to be a stream packet from now on
-  if (stream->socket != socket && stream->on_firewall != NULL) {
+  if (stream->socket != socket && stream->on_firewall != NULL && should_firewall) {
     if (is_addr_v4_mapped((struct sockaddr *) addr)) {
       addr_to_v4((struct sockaddr_in6 *) addr);
     }
@@ -1498,7 +1504,6 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
   bool ack_advanced = seq_diff(ack, prior_remote_acked) > 0;
   bool data_inflight = stream->remote_acked != stream->seq;
   // todo: send data packet with seq=remote_acked-1
-  bool is_probe = type & UDX_HEADER_HEARTBEAT;
 
   if (is_probe) {
     send_ack(stream);

--- a/src/udx.c
+++ b/src/udx.c
@@ -2517,6 +2517,9 @@ udx_stream_connect (udx_stream_t *stream, udx_socket_t *socket, uint32_t remote_
     uv_timer_start(&stream->tlp_and_keepalive_timer, udx_keepalive_timeout, stream->keepalive_timeout_ms, 0);
   }
 
+  // Let passive relays learn this endpoint before the first data packet.
+  send_probe(stream);
+
   return 0;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@ list(APPEND tests
   stream-destroy-slowpath
   stream-destroy-before-connect
   stream-preconnect
+  stream-preconnect-probe-firewall
   stream-preconnect-same-socket
   stream-relay
   stream-relay-force-slow-path

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ list(APPEND tests
   stream-preconnect-same-socket
   stream-relay
   stream-relay-force-slow-path
+  stream-relay-passive-startup
   stream-send-recv
   stream-send-recv-ipv6
   stream-write-read

--- a/test/stream-preconnect-probe-firewall.c
+++ b/test/stream-preconnect-probe-firewall.c
@@ -1,0 +1,119 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../include/udx.h"
+
+uv_loop_t loop;
+udx_t udx;
+
+struct sockaddr_storage addr;
+int addr_len = sizeof(addr);
+
+udx_socket_t sock;
+udx_stream_t astream;
+udx_stream_t bstream;
+
+uv_timer_t fail_timer;
+udx_stream_write_t *req;
+
+int firewall_calls = 0;
+int nclosed = 0;
+bool read_called = false;
+
+void
+on_close (udx_stream_t *stream, int status) {
+  nclosed++;
+
+  if (nclosed == 2) {
+    uv_timer_stop(&fail_timer);
+    uv_close((uv_handle_t *) &fail_timer, NULL);
+    udx_socket_close(&sock);
+  }
+}
+
+void
+on_fail_timeout (uv_timer_t *timer) {
+  assert(read_called && "preconnect stream did not receive first payload");
+}
+
+int
+on_firewall (udx_stream_t *stream, udx_socket_t *socket, const struct sockaddr *from) {
+  firewall_calls++;
+
+  // The connect probe should not trigger regular preconnect firewalls.
+  assert(firewall_calls == 1);
+
+  return 0;
+}
+
+void
+on_read (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf) {
+  assert(read_len == 5);
+  assert(buf->len == 5);
+  assert(memcmp(buf->base, "hello", 5) == 0);
+
+  read_called = true;
+
+  int e = udx_stream_connect(&astream, &sock, bstream.local_id, (struct sockaddr *) &addr);
+  assert(e == 0);
+
+  udx_stream_destroy(&astream);
+  udx_stream_destroy(&bstream);
+}
+
+int
+main () {
+  int e;
+
+  req = malloc(udx_stream_write_sizeof(1));
+
+  uv_loop_init(&loop);
+
+  e = udx_init(&loop, &udx, NULL);
+  assert(e == 0);
+
+  e = udx_socket_init(&udx, &sock, NULL);
+  assert(e == 0);
+
+  struct sockaddr_in bind_addr;
+  uv_ip4_addr("127.0.0.1", 0, &bind_addr);
+  e = udx_socket_bind(&sock, (struct sockaddr *) &bind_addr, 0);
+  assert(e == 0);
+
+  e = udx_socket_getsockname(&sock, (struct sockaddr *) &addr, &addr_len);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &astream, 1, on_close, NULL);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &bstream, 2, on_close, NULL);
+  assert(e == 0);
+
+  e = udx_stream_firewall(&astream, on_firewall);
+  assert(e == 0);
+
+  e = udx_stream_read_start(&astream, on_read);
+  assert(e == 0);
+
+  e = udx_stream_connect(&bstream, &sock, astream.local_id, (struct sockaddr *) &addr);
+  assert(e == 0);
+
+  uv_timer_init(&loop, &fail_timer);
+  uv_timer_start(&fail_timer, on_fail_timeout, 500, 0);
+
+  uv_buf_t buf = uv_buf_init("hello", 5);
+  e = udx_stream_write(req, &bstream, &buf, 1, NULL);
+  assert(e == 1);
+
+  e = uv_run(&loop, UV_RUN_DEFAULT);
+  assert(e == 0);
+
+  assert(read_called);
+  assert(firewall_calls == 1);
+
+  free(req);
+
+  return 0;
+}

--- a/test/stream-preconnect-probe-firewall.c
+++ b/test/stream-preconnect-probe-firewall.c
@@ -5,6 +5,10 @@
 
 #include "../include/udx.h"
 
+// Regression for regular preconnect streams. The relay startup fix sends a
+// heartbeat on connect, but that heartbeat must not make non-relay streams run
+// their firewall before the first application packet.
+
 uv_loop_t loop;
 udx_t udx;
 
@@ -42,7 +46,8 @@ int
 on_firewall (udx_stream_t *stream, udx_socket_t *socket, const struct sockaddr *from) {
   firewall_calls++;
 
-  // The connect probe should not trigger regular preconnect firewalls.
+  // If the connect heartbeat triggered this callback, the following data packet
+  // would be the second firewall call and fail this assertion.
   assert(firewall_calls == 1);
 
   return 0;
@@ -91,18 +96,23 @@ main () {
   e = udx_stream_init(&udx, &bstream, 2, on_close, NULL);
   assert(e == 0);
 
+  // astream starts unconnected, matching the normal preconnect flow used by
+  // udx-native. Only real data should make this firewall run.
   e = udx_stream_firewall(&astream, on_firewall);
   assert(e == 0);
 
   e = udx_stream_read_start(&astream, on_read);
   assert(e == 0);
 
+  // bstream.connect() sends the new heartbeat probe. This test ensures that
+  // probe is ignored by a regular preconnect firewall.
   e = udx_stream_connect(&bstream, &sock, astream.local_id, (struct sockaddr *) &addr);
   assert(e == 0);
 
   uv_timer_init(&loop, &fail_timer);
   uv_timer_start(&fail_timer, on_fail_timeout, 500, 0);
 
+  // The first application payload should be what opens the preconnect firewall.
   uv_buf_t buf = uv_buf_init("hello", 5);
   e = udx_stream_write(req, &bstream, &buf, 1, NULL);
   assert(e == 1);

--- a/test/stream-relay-passive-startup.c
+++ b/test/stream-relay-passive-startup.c
@@ -117,6 +117,7 @@ main () {
   e = udx_stream_read_start(&astream, on_read);
   assert(e == 0);
 
+  // Endpoint connects should probe the passive relay streams before first data.
   e = udx_stream_connect(&astream, &sock, bstream.local_id, (struct sockaddr *) &addr);
   assert(e == 0);
 

--- a/test/stream-relay-passive-startup.c
+++ b/test/stream-relay-passive-startup.c
@@ -1,0 +1,141 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../include/udx.h"
+
+uv_loop_t loop;
+udx_t udx;
+
+struct sockaddr_storage addr;
+int addr_len = sizeof(addr);
+
+udx_socket_t sock;
+udx_stream_t astream;
+udx_stream_t bstream;
+udx_stream_t cstream;
+udx_stream_t dstream;
+
+uv_timer_t fail_timer;
+udx_stream_write_t *req;
+
+bool read_called = false;
+int nclosed = 0;
+
+void
+on_close (udx_stream_t *stream, int status) {
+  nclosed++;
+
+  if (nclosed == 4) {
+    uv_timer_stop(&fail_timer);
+    uv_close((uv_handle_t *) &fail_timer, NULL);
+    udx_socket_close(&sock);
+  }
+}
+
+void
+on_fail_timeout (uv_timer_t *timer) {
+  assert(read_called && "passive relay did not deliver the first payload before RTO");
+}
+
+void
+on_read (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf) {
+  assert(read_len == 5);
+  assert(buf->len == 5);
+  assert(memcmp(buf->base, "hello", 5) == 0);
+
+  read_called = true;
+
+  udx_stream_destroy(&astream);
+  udx_stream_destroy(&bstream);
+  udx_stream_destroy(&cstream);
+  udx_stream_destroy(&dstream);
+}
+
+int
+on_b_firewall (udx_stream_t *stream, udx_socket_t *socket, const struct sockaddr *from) {
+  int e = udx_stream_connect(&bstream, socket, astream.local_id, from);
+  assert(e == 0);
+  return 0;
+}
+
+int
+on_c_firewall (udx_stream_t *stream, udx_socket_t *socket, const struct sockaddr *from) {
+  int e = udx_stream_connect(&cstream, socket, dstream.local_id, from);
+  assert(e == 0);
+  return 0;
+}
+
+int
+main () {
+  int e;
+
+  req = malloc(udx_stream_write_sizeof(1));
+
+  uv_loop_init(&loop);
+
+  e = udx_init(&loop, &udx, NULL);
+  assert(e == 0);
+
+  e = udx_socket_init(&udx, &sock, NULL);
+  assert(e == 0);
+
+  struct sockaddr_in bind_addr;
+  uv_ip4_addr("127.0.0.1", 0, &bind_addr);
+  e = udx_socket_bind(&sock, (struct sockaddr *) &bind_addr, 0);
+  assert(e == 0);
+
+  e = udx_socket_getsockname(&sock, (struct sockaddr *) &addr, &addr_len);
+  assert(e == 0);
+
+  // a/d are the endpoints; b/c are the passive relay streams between them.
+  e = udx_stream_init(&udx, &astream, 1, on_close, NULL);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &bstream, 2, on_close, NULL);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &cstream, 3, on_close, NULL);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &dstream, 4, on_close, NULL);
+  assert(e == 0);
+
+  e = udx_stream_firewall(&bstream, on_b_firewall);
+  assert(e == 0);
+
+  e = udx_stream_firewall(&cstream, on_c_firewall);
+  assert(e == 0);
+
+  e = udx_stream_relay_to(&cstream, &bstream);
+  assert(e == 0);
+
+  e = udx_stream_relay_to(&bstream, &cstream);
+  assert(e == 0);
+
+  e = udx_stream_read_start(&astream, on_read);
+  assert(e == 0);
+
+  e = udx_stream_connect(&astream, &sock, bstream.local_id, (struct sockaddr *) &addr);
+  assert(e == 0);
+
+  e = udx_stream_connect(&dstream, &sock, cstream.local_id, (struct sockaddr *) &addr);
+  assert(e == 0);
+
+  uv_timer_init(&loop, &fail_timer);
+  uv_timer_start(&fail_timer, on_fail_timeout, 500, 0);
+
+  uv_buf_t buf = uv_buf_init("hello", 5);
+  e = udx_stream_write(req, &dstream, &buf, 1, NULL);
+  assert(e == 1);
+
+  e = uv_run(&loop, UV_RUN_DEFAULT);
+  assert(e == 0);
+
+  assert(read_called);
+
+  free(req);
+
+  return 0;
+}


### PR DESCRIPTION
Fix passive relay startup by sending a stream probe from udx_stream_connect(). This lets relay streams learn the endpoint socket/address before the first application data packet, avoiding the initial payload being delayed until retransmit.

In local testing, the first relayed payload now arrives immediately instead of waiting for a retransmit. 


Co-written with AI