### PR TITLE
fix: buffer early relay packets

### DIFF
--- a/include/udx.h
+++ b/include/udx.h
@@ -252,6 +252,7 @@ struct udx_stream_s {
   bool relayed;
   udx_stream_t *relay_to;
   udx_cirbuf_t relaying_streams;
+  udx_queue_t pending_relay_packets;
 
   struct sockaddr_storage remote_addr;
   int remote_addr_len;

--- a/src/udx.c
+++ b/src/udx.c
@@ -37,6 +37,7 @@
 #define UDX_DEFAULT_SNDBUF_SIZE 212992
 
 #define UDX_MAX_RTO_TIMEOUTS 6
+#define UDX_MAX_PENDING_RELAY_PACKETS 64
 
 #define UDX_RTO_MAX_MS        30000
 #define UDX_RTT_MAX_MS        30000
@@ -63,6 +64,12 @@ typedef struct {
 
   uv_buf_t buf;
 } udx_pending_read_t;
+
+typedef struct udx_pending_relay_packet_s {
+  udx_queue_node_t queue;
+  size_t len;
+  char data[];
+} udx_pending_relay_packet_t;
 
 static uint32_t
 seq_max (uint32_t a, uint32_t b) {
@@ -159,6 +166,16 @@ clear_incoming_packets (udx_stream_t *stream) {
     if (pkt == NULL) continue;
 
     stream->pkts_buffered--;
+    free(pkt);
+  }
+}
+
+static void
+clear_pending_relay_packets (udx_stream_t *stream) {
+  udx_queue_node_t *node;
+
+  while ((node = udx__queue_shift(&stream->pending_relay_packets)) != NULL) {
+    udx_pending_relay_packet_t *pkt = udx__queue_data(node, udx_pending_relay_packet_t, queue);
     free(pkt);
   }
 }
@@ -405,6 +422,7 @@ close_stream_internal (udx_stream_t *stream, int err) {
 
   clear_outgoing_packets(stream);
   clear_incoming_packets(stream);
+  clear_pending_relay_packets(stream);
 
   // TODO: move the instance to a TIME_WAIT state, so we can handle retransmits
 
@@ -1373,6 +1391,86 @@ process_data_packet (udx_stream_t *stream, int type, uint32_t seq, char *data, s
   udx__cirbuf_set(&(stream->incoming), (udx_cirbuf_val_t *) pkt);
 }
 
+static void
+forward_relay_packet (udx_stream_t *stream, udx_stream_t *relay, char *buf, ssize_t buf_len) {
+  assert(stream->socket != NULL);
+  assert(relay->socket != NULL);
+
+  uint32_t *h = (uint32_t *) buf;
+  h[1] = udx__swap_uint32_if_be(relay->remote_id);
+
+  uv_buf_t b = uv_buf_init(buf, buf_len);
+
+  int err;
+
+  if (stream->udx->debug_flags & UDX_DEBUG_FORCE_RELAY_SLOW_PATH) {
+    err = UV_EAGAIN;
+  } else {
+    err = uv_udp_try_send(&stream->socket->uv_udp, &b, 1, (struct sockaddr *) &relay->remote_addr);
+  }
+
+  if (err == UV_EAGAIN) {
+    // create a socket_send_t with no callback to send this packet on the relay's send_queue
+
+    uv_udp_send_t *req = malloc(sizeof(uv_udp_send_t) + b.len);
+
+    char *data = (char *) (req + 1);
+    memcpy(data, buf, buf_len);
+    b = uv_buf_init(data, b.len);
+
+    err = uv_udp_send(req, &stream->socket->uv_udp, &b, 1, (struct sockaddr *) &relay->remote_addr, on_packet_send_slow);
+  }
+
+  if (err < 0) {
+    debug_printf("uv_udp_send error: %s\n", uv_strerror(err));
+  }
+}
+
+static int
+queue_relay_packet (udx_stream_t *stream, char *buf, ssize_t buf_len) {
+  if (stream->pending_relay_packets.len >= UDX_MAX_PENDING_RELAY_PACKETS) return UV_ENOBUFS;
+
+  udx_pending_relay_packet_t *pkt = malloc(sizeof(udx_pending_relay_packet_t) + buf_len);
+  if (pkt == NULL) return UV_ENOMEM;
+
+  pkt->len = buf_len;
+  memcpy(pkt->data, buf, buf_len);
+
+  udx__queue_tail(&stream->pending_relay_packets, &pkt->queue);
+
+  return 0;
+}
+
+static void
+flush_pending_relay_packets (udx_stream_t *stream) {
+  udx_stream_t *relay = stream->relay_to;
+
+  if (relay == NULL || relay->socket == NULL) return;
+
+  udx_queue_node_t *node;
+
+  while ((node = udx__queue_shift(&stream->pending_relay_packets)) != NULL) {
+    udx_pending_relay_packet_t *pkt = udx__queue_data(node, udx_pending_relay_packet_t, queue);
+    forward_relay_packet(stream, relay, pkt->data, pkt->len);
+    free(pkt);
+  }
+}
+
+static void
+flush_pending_relay_packets_to (udx_stream_t *relay) {
+  if (relay->socket == NULL) return;
+
+  udx_cirbuf_t relaying = relay->relaying_streams;
+
+  for (uint32_t i = 0; i < relaying.size; i++) {
+    udx_stream_t *stream = (udx_stream_t *) relaying.values[i];
+
+    if (stream && stream->relay_to == relay) {
+      flush_pending_relay_packets(stream);
+    }
+  }
+}
+
 static int
 relay_packet (udx_stream_t *stream, char *buf, ssize_t buf_len, int type, uint32_t seq) {
 
@@ -1381,30 +1479,12 @@ relay_packet (udx_stream_t *stream, char *buf, ssize_t buf_len, int type, uint32
   udx_stream_t *relay = stream->relay_to;
 
   if (relay->socket != NULL) {
-
-    uint32_t *h = (uint32_t *) buf;
-    h[1] = udx__swap_uint32_if_be(relay->remote_id);
-
-    uv_buf_t b = uv_buf_init(buf, buf_len);
-
-    int err;
-
-    if (stream->udx->debug_flags & UDX_DEBUG_FORCE_RELAY_SLOW_PATH) {
-      err = UV_EAGAIN;
-    } else {
-      err = uv_udp_try_send(&stream->socket->uv_udp, &b, 1, (struct sockaddr *) &relay->remote_addr);
-    }
-
-    if (err == UV_EAGAIN) {
-      // create a socket_send_t with no callback to send this packet on the relay's send_queue
-
-      uv_udp_send_t *req = malloc(sizeof(uv_udp_send_t) + b.len);
-
-      char *data = (char *) (req + 1);
-      memcpy(data, buf, buf_len);
-      b = uv_buf_init(data, b.len);
-
-      err = uv_udp_send(req, &stream->socket->uv_udp, &b, 1, (struct sockaddr *) &relay->remote_addr, on_packet_send_slow);
+    forward_relay_packet(stream, relay, buf, buf_len);
+  } else {
+    int err = queue_relay_packet(stream, buf, buf_len);
+    if (err) {
+      close_stream(stream, err);
+      return 1;
     }
   }
 
@@ -2258,6 +2338,7 @@ udx_stream_init (udx_t *udx, udx_stream_t *stream, uint32_t local_id, udx_stream
   udx__queue_init(&stream->inflight_queue);
   udx__queue_init(&stream->retransmit_queue);
   udx__queue_init(&stream->write_queue);
+  udx__queue_init(&stream->pending_relay_packets);
 
   stream->ssthresh = 0xffff;
   stream->cwnd = 10;
@@ -2525,6 +2606,7 @@ udx_stream_connect (udx_stream_t *stream, udx_socket_t *socket, uint32_t remote_
 
   // Let passive relays learn this endpoint before the first data packet.
   send_probe(stream, false);
+  flush_pending_relay_packets_to(stream);
 
   return 0;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,9 @@ list(APPEND tests
   stream-relay
   stream-relay-force-slow-path
   stream-relay-passive-startup
+  stream-relay-pending-startup
+  stream-relay-pending-cleanup
+  stream-relay-pending-overflow
   stream-send-recv
   stream-send-recv-ipv6
   stream-write-read

--- a/test/stream-relay-pending-cleanup.c
+++ b/test/stream-relay-pending-cleanup.c
@@ -1,0 +1,142 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "../include/udx.h"
+
+uv_loop_t loop;
+udx_t udx;
+
+struct sockaddr_storage addr;
+int addr_len = sizeof(addr);
+
+udx_socket_t sock;
+udx_stream_t astream;
+udx_stream_t bstream;
+udx_stream_t cstream;
+udx_stream_t dstream;
+
+uv_timer_t destroy_timer;
+uv_timer_t fail_timer;
+udx_stream_write_t *req;
+
+int nclosed = 0;
+int nfinalized = 0;
+bool socket_closed = false;
+
+void
+on_socket_close (udx_socket_t *socket) {
+  socket_closed = true;
+}
+
+void
+on_close (udx_stream_t *stream, int status) {
+  nclosed++;
+
+  if (nclosed == 4) {
+    uv_timer_stop(&fail_timer);
+    uv_close((uv_handle_t *) &fail_timer, NULL);
+    udx_socket_close(&sock);
+  }
+}
+
+void
+on_finalize (udx_stream_t *stream) {
+  nfinalized++;
+}
+
+int
+on_c_firewall (udx_stream_t *stream, udx_socket_t *socket, const struct sockaddr *from) {
+  int e = udx_stream_connect(&cstream, socket, dstream.local_id, from);
+  assert(e == 0);
+  return 0;
+}
+
+void
+on_destroy_timeout (uv_timer_t *timer) {
+  uv_timer_stop(&destroy_timer);
+  uv_close((uv_handle_t *) &destroy_timer, NULL);
+
+  udx_stream_destroy(&astream);
+  udx_stream_destroy(&bstream);
+  udx_stream_destroy(&cstream);
+  udx_stream_destroy(&dstream);
+}
+
+void
+on_fail_timeout (uv_timer_t *timer) {
+  assert(false && "pending relay packet cleanup timed out");
+}
+
+int
+main () {
+  int e;
+
+  req = malloc(udx_stream_write_sizeof(1));
+
+  uv_loop_init(&loop);
+
+  e = udx_init(&loop, &udx, NULL);
+  assert(e == 0);
+
+  e = udx_socket_init(&udx, &sock, on_socket_close);
+  assert(e == 0);
+
+  struct sockaddr_in bind_addr;
+  uv_ip4_addr("127.0.0.1", 0, &bind_addr);
+  e = udx_socket_bind(&sock, (struct sockaddr *) &bind_addr, 0);
+  assert(e == 0);
+
+  e = udx_socket_getsockname(&sock, (struct sockaddr *) &addr, &addr_len);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &astream, 1, on_close, on_finalize);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &bstream, 2, on_close, on_finalize);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &cstream, 3, on_close, on_finalize);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &dstream, 4, on_close, on_finalize);
+  assert(e == 0);
+
+  e = udx_stream_firewall(&cstream, on_c_firewall);
+  assert(e == 0);
+
+  e = udx_stream_relay_to(&cstream, &bstream);
+  assert(e == 0);
+
+  e = udx_stream_relay_to(&bstream, &cstream);
+  assert(e == 0);
+
+  // d sends before a connects, leaving c->b relay packets pending. The test
+  // then destroys every stream to cover queued-packet cleanup/finalization.
+  e = udx_stream_connect(&dstream, &sock, cstream.local_id, (struct sockaddr *) &addr);
+  assert(e == 0);
+
+  uv_buf_t buf = uv_buf_init("hello", 5);
+  e = udx_stream_write(req, &dstream, &buf, 1, NULL);
+  assert(e == 1);
+
+  uv_timer_init(&loop, &destroy_timer);
+  uv_timer_start(&destroy_timer, on_destroy_timeout, 50, 0);
+
+  uv_timer_init(&loop, &fail_timer);
+  uv_timer_start(&fail_timer, on_fail_timeout, 500, 0);
+
+  e = uv_run(&loop, UV_RUN_DEFAULT);
+  assert(e == 0);
+
+  assert(nclosed == 4);
+  assert(nfinalized == 4);
+  assert(socket_closed);
+
+  e = uv_loop_close(&loop);
+  assert(e == 0);
+
+  free(req);
+
+  return 0;
+}

--- a/test/stream-relay-pending-overflow.c
+++ b/test/stream-relay-pending-overflow.c
@@ -1,0 +1,153 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../include/udx.h"
+
+#define PAYLOAD_SIZE (256 * 1024)
+
+uv_loop_t loop;
+udx_t udx;
+
+struct sockaddr_storage addr;
+int addr_len = sizeof(addr);
+
+udx_socket_t sock;
+udx_stream_t astream;
+udx_stream_t bstream;
+udx_stream_t cstream;
+udx_stream_t dstream;
+
+uv_timer_t fail_timer;
+uv_timer_t cleanup_timer;
+udx_stream_write_t *req;
+char *payload;
+
+int nclosed = 0;
+bool overflow_seen = false;
+bool socket_closed = false;
+
+void
+on_socket_close (udx_socket_t *socket) {
+  socket_closed = true;
+}
+
+void
+on_cleanup_timeout (uv_timer_t *timer) {
+  uv_timer_stop(&cleanup_timer);
+  uv_close((uv_handle_t *) &cleanup_timer, NULL);
+
+  udx_stream_destroy(&astream);
+  udx_stream_destroy(&bstream);
+  udx_stream_destroy(&dstream);
+}
+
+void
+on_close (udx_stream_t *stream, int status) {
+  nclosed++;
+
+  if (stream == &cstream) {
+    assert(status == UV_ENOBUFS);
+    overflow_seen = true;
+    uv_timer_start(&cleanup_timer, on_cleanup_timeout, 0, 0);
+  }
+
+  if (nclosed == 4) {
+    uv_timer_stop(&fail_timer);
+    uv_close((uv_handle_t *) &fail_timer, NULL);
+    udx_socket_close(&sock);
+  }
+}
+
+int
+on_c_firewall (udx_stream_t *stream, udx_socket_t *socket, const struct sockaddr *from) {
+  int e = udx_stream_connect(&cstream, socket, dstream.local_id, from);
+  assert(e == 0);
+  return 0;
+}
+
+void
+on_fail_timeout (uv_timer_t *timer) {
+  assert(overflow_seen && "pending relay packet overflow did not close the relay stream");
+}
+
+int
+main () {
+  int e;
+
+  req = malloc(udx_stream_write_sizeof(1));
+  payload = malloc(PAYLOAD_SIZE);
+  memset(payload, 'x', PAYLOAD_SIZE);
+
+  uv_loop_init(&loop);
+
+  e = udx_init(&loop, &udx, NULL);
+  assert(e == 0);
+
+  e = udx_socket_init(&udx, &sock, on_socket_close);
+  assert(e == 0);
+
+  struct sockaddr_in bind_addr;
+  uv_ip4_addr("127.0.0.1", 0, &bind_addr);
+  e = udx_socket_bind(&sock, (struct sockaddr *) &bind_addr, 0);
+  assert(e == 0);
+
+  e = udx_socket_getsockname(&sock, (struct sockaddr *) &addr, &addr_len);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &astream, 1, on_close, NULL);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &bstream, 2, on_close, NULL);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &cstream, 3, on_close, NULL);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &dstream, 4, on_close, NULL);
+  assert(e == 0);
+
+  e = udx_stream_firewall(&cstream, on_c_firewall);
+  assert(e == 0);
+
+  e = udx_stream_relay_to(&cstream, &bstream);
+  assert(e == 0);
+
+  e = udx_stream_relay_to(&bstream, &cstream);
+  assert(e == 0);
+
+  e = udx_stream_connect(&dstream, &sock, cstream.local_id, (struct sockaddr *) &addr);
+  assert(e == 0);
+
+  // Make the sender able to fill the relay's bounded pending queue before RTO.
+  // Overflow must close the relayed stream instead of buffering without bound.
+  dstream.cwnd = 128;
+  dstream.send_rwnd = PAYLOAD_SIZE;
+  dstream.tb_available = PAYLOAD_SIZE;
+  dstream.pacing_bytes_per_ms = PAYLOAD_SIZE;
+
+  uv_timer_init(&loop, &cleanup_timer);
+
+  uv_buf_t buf = uv_buf_init(payload, PAYLOAD_SIZE);
+  e = udx_stream_write(req, &dstream, &buf, 1, NULL);
+  assert(e == 1);
+
+  uv_timer_init(&loop, &fail_timer);
+  uv_timer_start(&fail_timer, on_fail_timeout, 500, 0);
+
+  e = uv_run(&loop, UV_RUN_DEFAULT);
+  assert(e == 0);
+
+  assert(overflow_seen);
+  assert(nclosed == 4);
+  assert(socket_closed);
+
+  e = uv_loop_close(&loop);
+  assert(e == 0);
+
+  free(payload);
+  free(req);
+
+  return 0;
+}

--- a/test/stream-relay-pending-startup.c
+++ b/test/stream-relay-pending-startup.c
@@ -1,0 +1,173 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../include/udx.h"
+
+#define PAYLOAD_SIZE 8192
+
+uv_loop_t loop;
+udx_t udx;
+
+struct sockaddr_storage addr;
+int addr_len = sizeof(addr);
+
+udx_socket_t sock;
+udx_stream_t astream;
+udx_stream_t bstream;
+udx_stream_t cstream;
+udx_stream_t dstream;
+
+uv_timer_t connect_timer;
+uv_timer_t fail_timer;
+udx_stream_write_t *req;
+char *payload;
+
+bool read_called = false;
+size_t nread = 0;
+int nclosed = 0;
+
+void
+on_close (udx_stream_t *stream, int status) {
+  nclosed++;
+
+  if (nclosed == 4) {
+    uv_timer_stop(&fail_timer);
+    uv_close((uv_handle_t *) &fail_timer, NULL);
+    udx_socket_close(&sock);
+  }
+}
+
+void
+on_fail_timeout (uv_timer_t *timer) {
+  assert(read_called && "pending relay packet was not flushed before RTO");
+}
+
+void
+on_read (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf) {
+  assert(read_len > 0);
+  assert(buf->len == read_len);
+  assert(nread + read_len <= PAYLOAD_SIZE);
+
+  for (ssize_t i = 0; i < read_len; i++) {
+    assert(buf->base[i] == payload[nread + i]);
+  }
+
+  nread += read_len;
+
+  if (nread == PAYLOAD_SIZE) {
+    assert(dstream.rto_count == 0);
+
+    read_called = true;
+
+    udx_stream_destroy(&astream);
+    udx_stream_destroy(&bstream);
+    udx_stream_destroy(&cstream);
+    udx_stream_destroy(&dstream);
+  }
+}
+
+int
+on_b_firewall (udx_stream_t *stream, udx_socket_t *socket, const struct sockaddr *from) {
+  int e = udx_stream_connect(&bstream, socket, astream.local_id, from);
+  assert(e == 0);
+  return 0;
+}
+
+int
+on_c_firewall (udx_stream_t *stream, udx_socket_t *socket, const struct sockaddr *from) {
+  int e = udx_stream_connect(&cstream, socket, dstream.local_id, from);
+  assert(e == 0);
+  return 0;
+}
+
+void
+on_connect_timeout (uv_timer_t *timer) {
+  uv_timer_stop(&connect_timer);
+  uv_close((uv_handle_t *) &connect_timer, NULL);
+
+  int e = udx_stream_connect(&astream, &sock, bstream.local_id, (struct sockaddr *) &addr);
+  assert(e == 0);
+}
+
+int
+main () {
+  int e;
+
+  req = malloc(udx_stream_write_sizeof(1));
+  payload = malloc(PAYLOAD_SIZE);
+
+  for (int i = 0; i < PAYLOAD_SIZE; i++) {
+    payload[i] = (char) (i % 251);
+  }
+
+  uv_loop_init(&loop);
+
+  e = udx_init(&loop, &udx, NULL);
+  assert(e == 0);
+
+  e = udx_socket_init(&udx, &sock, NULL);
+  assert(e == 0);
+
+  struct sockaddr_in bind_addr;
+  uv_ip4_addr("127.0.0.1", 0, &bind_addr);
+  e = udx_socket_bind(&sock, (struct sockaddr *) &bind_addr, 0);
+  assert(e == 0);
+
+  e = udx_socket_getsockname(&sock, (struct sockaddr *) &addr, &addr_len);
+  assert(e == 0);
+
+  // a/d are endpoints; b/c are passive relay streams between them.
+  e = udx_stream_init(&udx, &astream, 1, on_close, NULL);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &bstream, 2, on_close, NULL);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &cstream, 3, on_close, NULL);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &dstream, 4, on_close, NULL);
+  assert(e == 0);
+
+  e = udx_stream_firewall(&bstream, on_b_firewall);
+  assert(e == 0);
+
+  e = udx_stream_firewall(&cstream, on_c_firewall);
+  assert(e == 0);
+
+  e = udx_stream_relay_to(&cstream, &bstream);
+  assert(e == 0);
+
+  e = udx_stream_relay_to(&bstream, &cstream);
+  assert(e == 0);
+
+  e = udx_stream_read_start(&astream, on_read);
+  assert(e == 0);
+
+  // d sends before a has connected. The payload spans multiple packets, so
+  // this verifies that pending relay packets flush in order before RTO.
+  e = udx_stream_connect(&dstream, &sock, cstream.local_id, (struct sockaddr *) &addr);
+  assert(e == 0);
+
+  uv_buf_t buf = uv_buf_init(payload, PAYLOAD_SIZE);
+  e = udx_stream_write(req, &dstream, &buf, 1, NULL);
+  assert(e == 1);
+
+  uv_timer_init(&loop, &connect_timer);
+  uv_timer_start(&connect_timer, on_connect_timeout, 50, 0);
+
+  uv_timer_init(&loop, &fail_timer);
+  uv_timer_start(&fail_timer, on_fail_timeout, 500, 0);
+
+  e = uv_run(&loop, UV_RUN_DEFAULT);
+  assert(e == 0);
+
+  assert(read_called);
+
+  free(req);
+  free(payload);
+
+  return 0;
+}


### PR DESCRIPTION
This buffers early relayed packets while the destination relay stream is still learning its socket, instead of dropping them and relying on retransmission. The queue is bounded, flushed once the destination connects, and cleared during stream cleanup.

I benchmarked this on a temporary on a remote Ubuntu 22.04 x86_64 instance with `udx-native` v1.20.6 and a HyperDHT relay connection using normal `NoiseSecretStream` sockets.

| Scenario | #288 only | #288 + #289 |
| --- | ---: | ---: |
| Secret-stream open p50 | 20ms | 17ms |
| Immediate first payload echo p50 | 515ms | 14ms |
| Immediate first payload echo p95 | 523ms | 23ms |
| Write-after-open echo p50 | 500ms | 0.3ms |

So #289 does not mainly change stream-open timing. It removes the recovery delay for the first secret-stream payload over a relayed connection.


Co-written with AI