### PR TITLE
fix: forward relayed packets from relay socket

### DIFF
--- a/src/udx.c
+++ b/src/udx.c
@@ -1391,7 +1391,7 @@ relay_packet (udx_stream_t *stream, char *buf, ssize_t buf_len, int type, uint32
     if (stream->udx->debug_flags & UDX_DEBUG_FORCE_RELAY_SLOW_PATH) {
       err = UV_EAGAIN;
     } else {
-      err = uv_udp_try_send(&stream->socket->uv_udp, &b, 1, (struct sockaddr *) &relay->remote_addr);
+      err = uv_udp_try_send(&relay->socket->uv_udp, &b, 1, (struct sockaddr *) &relay->remote_addr);
     }
 
     if (err == UV_EAGAIN) {
@@ -1403,7 +1403,7 @@ relay_packet (udx_stream_t *stream, char *buf, ssize_t buf_len, int type, uint32
       memcpy(data, buf, buf_len);
       b = uv_buf_init(data, b.len);
 
-      err = uv_udp_send(req, &stream->socket->uv_udp, &b, 1, (struct sockaddr *) &relay->remote_addr, on_packet_send_slow);
+      err = uv_udp_send(req, &relay->socket->uv_udp, &b, 1, (struct sockaddr *) &relay->remote_addr, on_packet_send_slow);
     }
   }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ list(APPEND tests
   stream-preconnect
   stream-preconnect-same-socket
   stream-relay
+  stream-relay-firewall-source
   stream-relay-force-slow-path
   stream-send-recv
   stream-send-recv-ipv6

--- a/test/stream-relay-firewall-source.c
+++ b/test/stream-relay-firewall-source.c
@@ -4,7 +4,6 @@
 #include <string.h>
 
 #include "../include/udx.h"
-#include "helpers.h"
 
 #define NBYTES_TO_SEND 1000000
 
@@ -34,8 +33,6 @@ typedef struct {
   bool read_called;
   bool firewall_called;
 
-  size_t write_hash;
-  size_t read_hash;
   size_t nbytes_read;
 
   int nclosed;
@@ -87,7 +84,6 @@ on_read (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf) {
     assert(memcmp(buf->base, "hello", 5) == 0);
   }
 
-  test->read_hash = hash(test->read_hash, (uint8_t *) buf->base, read_len);
   test->nbytes_read += read_len;
   test->read_called = true;
 }
@@ -130,10 +126,7 @@ bind_addr (udx_socket_t *socket, struct sockaddr_in *addr, int port) {
 
 static void
 run_case (int base_port, bool force_slow_path) {
-  test_case_t test = {
-    .write_hash = HASH_INIT,
-    .read_hash = HASH_INIT
-  };
+  test_case_t test = { 0 };
 
   udx_stream_write_t *req = malloc(udx_stream_write_sizeof(1));
   req->data = &test;
@@ -214,7 +207,6 @@ run_case (int base_port, bool force_slow_path) {
   uv_buf_t buf = uv_buf_init(data, NBYTES_TO_SEND);
 
   memcpy(buf.base, "hello", 5);
-  test.write_hash = hash(test.write_hash, (uint8_t *) buf.base, buf.len);
 
   uv_timer_init(&test.loop, &test.timeout);
   uv_timer_start(&test.timeout, on_timeout, 5000, 0);
@@ -229,11 +221,10 @@ run_case (int base_port, bool force_slow_path) {
   e = uv_loop_close(&test.loop);
   assert(e == 0);
 
-  // Ensure the firewalled path was actually used and the relayed payload made
-  // it through intact.
+  // Ensure the firewalled path was actually used and data made it through.
   assert(test.firewall_called);
   assert(test.ack_called && test.read_called);
-  assert(test.nbytes_read == NBYTES_TO_SEND && test.read_hash == test.write_hash);
+  assert(test.nbytes_read == NBYTES_TO_SEND);
 
   free(req);
   free(data);

--- a/test/stream-relay-firewall-source.c
+++ b/test/stream-relay-firewall-source.c
@@ -160,6 +160,8 @@ run_case (int base_port, bool force_slow_path) {
   e = udx_socket_init(&test.udx, &test.dsock, on_socket_close);
   assert(e == 0);
 
+  // Use a distinct socket/port per stream so a wrong forwarding socket is
+  // observable as the wrong UDP source port in the firewall callback.
   bind_addr(&test.asock, &test.aaddr, base_port + 1);
   bind_addr(&test.bsock, &test.baddr, base_port + 2);
   bind_addr(&test.csock, &test.caddr, base_port + 3);
@@ -181,9 +183,13 @@ run_case (int base_port, bool force_slow_path) {
   assert(e == 0);
   test.dstream.data = &test;
 
+  // A is the firewalled destination; on_firewall asserts that forwarded relay
+  // traffic arrives from B's socket, not from C's incoming stream socket.
   e = udx_stream_firewall(&test.astream, on_firewall);
   assert(e == 0);
 
+  // Pair B and C as the relay: data received by C should be forwarded to A
+  // using B's socket, which is the source A is expecting.
   e = udx_stream_relay_to(&test.cstream, &test.bstream);
   assert(e == 0);
 
@@ -193,6 +199,8 @@ run_case (int base_port, bool force_slow_path) {
   e = udx_stream_read_start(&test.astream, on_read);
   assert(e == 0);
 
+  // B is the relay leg visible to A; C/D create the incoming relay leg that
+  // triggers forwarding when D writes below.
   e = udx_stream_connect(&test.bstream, &test.bsock, 1, (struct sockaddr *) &test.aaddr);
   assert(e == 0);
 
@@ -211,6 +219,8 @@ run_case (int base_port, bool force_slow_path) {
   uv_timer_init(&test.loop, &test.timeout);
   uv_timer_start(&test.timeout, on_timeout, 5000, 0);
 
+  // Writing from D into C exercises relay_packet(cstream -> bstream). The
+  // regression sent this packet from C's socket instead of B's socket.
   udx_stream_write(req, &test.dstream, &buf, 1, on_ack);
 
   e = uv_run(&test.loop, UV_RUN_DEFAULT);
@@ -219,6 +229,8 @@ run_case (int base_port, bool force_slow_path) {
   e = uv_loop_close(&test.loop);
   assert(e == 0);
 
+  // Ensure the firewalled path was actually used and the relayed payload made
+  // it through intact.
   assert(test.firewall_called);
   assert(test.ack_called && test.read_called);
   assert(test.nbytes_read == NBYTES_TO_SEND && test.read_hash == test.write_hash);

--- a/test/stream-relay-firewall-source.c
+++ b/test/stream-relay-firewall-source.c
@@ -1,0 +1,244 @@
+#include <assert.h>
+#include <arpa/inet.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../include/udx.h"
+#include "helpers.h"
+
+#define NBYTES_TO_SEND 1000000
+
+typedef struct {
+  uv_loop_t loop;
+  udx_t udx;
+
+  struct sockaddr_in aaddr;
+  udx_socket_t asock;
+  udx_stream_t astream;
+
+  struct sockaddr_in baddr;
+  udx_socket_t bsock;
+  udx_stream_t bstream;
+
+  struct sockaddr_in caddr;
+  udx_socket_t csock;
+  udx_stream_t cstream;
+
+  struct sockaddr_in daddr;
+  udx_socket_t dsock;
+  udx_stream_t dstream;
+
+  uv_timer_t timeout;
+
+  bool ack_called;
+  bool read_called;
+  bool firewall_called;
+
+  size_t write_hash;
+  size_t read_hash;
+  size_t nbytes_read;
+
+  int expected_relay_source_port;
+  int nclosed;
+} test_case_t;
+
+static int
+port_of (const struct sockaddr *addr) {
+  assert(addr->sa_family == AF_INET);
+  return ntohs(((const struct sockaddr_in *) addr)->sin_port);
+}
+
+static int
+on_firewall (udx_stream_t *stream, udx_socket_t *socket, const struct sockaddr *from) {
+  test_case_t *test = stream->data;
+
+  assert(stream == &test->astream);
+  assert(socket == &test->asock);
+
+  test->firewall_called = true;
+
+  // Relayed packets must arrive from the paired relay stream's socket, not
+  // from the incoming stream socket that happened to forward the packet.
+  assert(port_of(from) == test->expected_relay_source_port);
+
+  int e = udx_stream_connect(&test->astream, socket, 2, from);
+  assert(e == 0);
+
+  return 0;
+}
+
+static void
+on_ack (udx_stream_write_t *req, int status, int unordered) {
+  test_case_t *test = req->data;
+
+  assert(status == 0);
+
+  udx_stream_destroy(&test->astream);
+  udx_stream_destroy(&test->bstream);
+  udx_stream_destroy(&test->cstream);
+  udx_stream_destroy(&test->dstream);
+
+  test->ack_called = true;
+}
+
+static void
+on_read (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf) {
+  test_case_t *test = stream->data;
+
+  if (read_len < 0) return;
+
+  assert(buf->len == read_len);
+
+  if (test->nbytes_read == 0) {
+    assert(memcmp(buf->base, "hello", 5) == 0);
+  }
+
+  test->read_hash = hash(test->read_hash, (uint8_t *) buf->base, read_len);
+  test->nbytes_read += read_len;
+  test->read_called = true;
+}
+
+static void
+on_socket_close (udx_socket_t *socket) {
+  (void) socket;
+}
+
+static void
+on_close (udx_stream_t *stream, int err) {
+  test_case_t *test = stream->data;
+
+  test->nclosed++;
+
+  if (test->nclosed == 4) {
+    uv_timer_stop(&test->timeout);
+    uv_close((uv_handle_t *) &test->timeout, NULL);
+
+    udx_socket_close(&test->asock);
+    udx_socket_close(&test->bsock);
+    udx_socket_close(&test->csock);
+    udx_socket_close(&test->dsock);
+  }
+}
+
+static void
+on_timeout (uv_timer_t *timer) {
+  assert(false && "relay source firewall test timed out");
+}
+
+static void
+bind_addr (udx_socket_t *socket, struct sockaddr_in *addr, int port) {
+  int e = uv_ip4_addr("127.0.0.1", port, addr);
+  assert(e == 0);
+
+  e = udx_socket_bind(socket, (struct sockaddr *) addr, 0);
+  assert(e == 0);
+}
+
+static void
+run_case (int base_port, bool force_slow_path) {
+  test_case_t test = {
+    .write_hash = HASH_INIT,
+    .read_hash = HASH_INIT,
+    .expected_relay_source_port = base_port + 2
+  };
+
+  udx_stream_write_t *req = malloc(udx_stream_write_sizeof(1));
+  req->data = &test;
+
+  int e = uv_loop_init(&test.loop);
+  assert(e == 0);
+
+  e = udx_init(&test.loop, &test.udx, NULL);
+  assert(e == 0);
+
+  if (force_slow_path) {
+    test.udx.debug_flags |= UDX_DEBUG_FORCE_RELAY_SLOW_PATH;
+  }
+
+  e = udx_socket_init(&test.udx, &test.asock, on_socket_close);
+  assert(e == 0);
+
+  e = udx_socket_init(&test.udx, &test.bsock, on_socket_close);
+  assert(e == 0);
+
+  e = udx_socket_init(&test.udx, &test.csock, on_socket_close);
+  assert(e == 0);
+
+  e = udx_socket_init(&test.udx, &test.dsock, on_socket_close);
+  assert(e == 0);
+
+  bind_addr(&test.asock, &test.aaddr, base_port + 1);
+  bind_addr(&test.bsock, &test.baddr, base_port + 2);
+  bind_addr(&test.csock, &test.caddr, base_port + 3);
+  bind_addr(&test.dsock, &test.daddr, base_port + 4);
+
+  e = udx_stream_init(&test.udx, &test.astream, 1, on_close, NULL);
+  assert(e == 0);
+  test.astream.data = &test;
+
+  e = udx_stream_init(&test.udx, &test.bstream, 2, on_close, NULL);
+  assert(e == 0);
+  test.bstream.data = &test;
+
+  e = udx_stream_init(&test.udx, &test.cstream, 3, on_close, NULL);
+  assert(e == 0);
+  test.cstream.data = &test;
+
+  e = udx_stream_init(&test.udx, &test.dstream, 4, on_close, NULL);
+  assert(e == 0);
+  test.dstream.data = &test;
+
+  e = udx_stream_firewall(&test.astream, on_firewall);
+  assert(e == 0);
+
+  e = udx_stream_relay_to(&test.cstream, &test.bstream);
+  assert(e == 0);
+
+  e = udx_stream_relay_to(&test.bstream, &test.cstream);
+  assert(e == 0);
+
+  e = udx_stream_read_start(&test.astream, on_read);
+  assert(e == 0);
+
+  e = udx_stream_connect(&test.bstream, &test.bsock, 1, (struct sockaddr *) &test.aaddr);
+  assert(e == 0);
+
+  e = udx_stream_connect(&test.cstream, &test.csock, 4, (struct sockaddr *) &test.daddr);
+  assert(e == 0);
+
+  e = udx_stream_connect(&test.dstream, &test.dsock, 3, (struct sockaddr *) &test.caddr);
+  assert(e == 0);
+
+  char *data = calloc(NBYTES_TO_SEND, 1);
+  uv_buf_t buf = uv_buf_init(data, NBYTES_TO_SEND);
+
+  memcpy(buf.base, "hello", 5);
+  test.write_hash = hash(test.write_hash, (uint8_t *) buf.base, buf.len);
+
+  uv_timer_init(&test.loop, &test.timeout);
+  uv_timer_start(&test.timeout, on_timeout, 5000, 0);
+
+  udx_stream_write(req, &test.dstream, &buf, 1, on_ack);
+
+  e = uv_run(&test.loop, UV_RUN_DEFAULT);
+  assert(e == 0);
+
+  e = uv_loop_close(&test.loop);
+  assert(e == 0);
+
+  assert(test.firewall_called);
+  assert(test.ack_called && test.read_called);
+  assert(test.nbytes_read == NBYTES_TO_SEND && test.read_hash == test.write_hash);
+
+  free(req);
+  free(data);
+}
+
+int
+main () {
+  run_case(8080, false);
+  run_case(8090, true);
+
+  return 0;
+}

--- a/test/stream-relay-firewall-source.c
+++ b/test/stream-relay-firewall-source.c
@@ -1,5 +1,4 @@
 #include <assert.h>
-#include <arpa/inet.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -39,15 +38,8 @@ typedef struct {
   size_t read_hash;
   size_t nbytes_read;
 
-  int expected_relay_source_port;
   int nclosed;
 } test_case_t;
-
-static int
-port_of (const struct sockaddr *addr) {
-  assert(addr->sa_family == AF_INET);
-  return ntohs(((const struct sockaddr_in *) addr)->sin_port);
-}
 
 static int
 on_firewall (udx_stream_t *stream, udx_socket_t *socket, const struct sockaddr *from) {
@@ -60,7 +52,8 @@ on_firewall (udx_stream_t *stream, udx_socket_t *socket, const struct sockaddr *
 
   // Relayed packets must arrive from the paired relay stream's socket, not
   // from the incoming stream socket that happened to forward the packet.
-  assert(port_of(from) == test->expected_relay_source_port);
+  assert(from->sa_family == AF_INET);
+  assert(((const struct sockaddr_in *) from)->sin_port == test->baddr.sin_port);
 
   int e = udx_stream_connect(&test->astream, socket, 2, from);
   assert(e == 0);
@@ -139,8 +132,7 @@ static void
 run_case (int base_port, bool force_slow_path) {
   test_case_t test = {
     .write_hash = HASH_INIT,
-    .read_hash = HASH_INIT,
-    .expected_relay_source_port = base_port + 2
+    .read_hash = HASH_INIT
   };
 
   udx_stream_write_t *req = malloc(udx_stream_write_sizeof(1));


### PR DESCRIPTION
The bug is that the forwarded packet should therefore be sent from `relay->socket`, not `stream->socket`,  This appears to have regressed in [bbb5901990d83e1af41af155be586a9a492c8480](https://github.com/holepunchto/libudx/commit/bbb5901990d83e1af41af155be586a9a492c8480)  ( I checkout various points in time to isolate the commit)



```text
A <-- bstream.socket   relay   cstream.socket <-- D

D -> cstream.socket  relay  bstream.socket -> A   correct
D -> cstream.socket  relay  cstream.socket -> A   wrong
```

### Why this can flake in HyperDHT/blind-relay:

HyperDHT classifies incoming packets in its firewall callback. It treats a packet as relay traffic only if it came from the expected relay raw stream socket and expected relay remote host/port:

- [`connect.js` firewall relay check](https://github.com/holepunchto/hyperdht/blob/af6ac6782dcfce32aec5fe8ebda1c06a5416faf1/lib/connect.js#L134-L145)
- [`connect.js` `isRelay()` socket/host/port match](https://github.com/holepunchto/hyperdht/blob/af6ac6782dcfce32aec5fe8ebda1c06a5416faf1/lib/connect.js#L865-L870)

That expected tuple is taken from `relaySocket.rawStream` when relay pairing completes:

- [`connect.js` relay pairing attaches `rawStream` to relay socket tuple](https://github.com/holepunchto/hyperdht/blob/af6ac6782dcfce32aec5fe8ebda1c06a5416faf1/lib/connect.js#L801-L823)

The same shape exists on the server side:

- [`server.js` firewall relay check](https://github.com/holepunchto/hyperdht/blob/af6ac6782dcfce32aec5fe8ebda1c06a5416faf1/lib/server.js#L287-L299)
- [`server.js` relay pairing attaches `rawStream` to relay socket tuple](https://github.com/holepunchto/hyperdht/blob/af6ac6782dcfce32aec5fe8ebda1c06a5416faf1/lib/server.js#L654-L680)

With the bug, a forwarded packet can arrive from the incoming relay leg’s socket instead of the paired outgoing relay leg’s socket. HyperDHT can then classify it as not coming from the relay path it expects. Whether this breaks the connection depends on timing: if the expected relay tuple is established and used first, the connection may continue; if a wrong-source forwarded packet wins the startup race, HyperDHT can update/classify the wrong path and the connection can stall or timeout.

### Why constantly failing when server is firewalled 

When the relay is firewalled, the receiver relies on the packet’s UDP source address/port to validate and establish the relay path. The bug sent forwarded packets from stream->socket instead of the paired relay->socket, so those packets arrived from the wrong source and the firewalled path could fail consistently.

### Testing I did
I tested by deploying a relay where inbound UDP was blocked except for the relay service port, then ran the blind-relay-testing nightly probe against it so the peers had to establish the connection through the firewalled relay path.

| Relay setup | Result |
| --- | --- |
| `udx-native@1.20.6`, `hyperdht@6.32.0` | failed 3/3 |
| `udx-native@1.19.2`, `hyperdht@6.29.6` | passed full probe |
| `udx-native@1.20.6` rebuilt with [libudx#291](https://github.com/holepunchto/libudx/pull/291), `hyperdht@6.32.0` | passed full probe |


Co-authored with AI