### PR TITLE
feat: expose stream receive source

### DIFF
--- a/include/udx.h
+++ b/include/udx.h
@@ -125,6 +125,19 @@ typedef void (*udx_stream_remote_changed_cb)(udx_stream_t *stream);
 typedef void (*udx_stream_ack_cb)(udx_stream_write_t *req, int status, int unordered);
 typedef void (*udx_stream_send_cb)(udx_stream_send_t *req, int status);
 typedef void (*udx_stream_recv_cb)(udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf);
+
+typedef enum {
+  UDX_STREAM_RECV_SOURCE_CURRENT = 0,
+  UDX_STREAM_RECV_SOURCE_OTHER = 1,
+} udx_stream_recv_source_t;
+
+typedef struct {
+  udx_socket_t *socket;
+  const struct sockaddr *from;
+  udx_stream_recv_source_t source;
+} udx_stream_recv_info_t;
+
+typedef void (*udx_stream_recv_with_info_cb)(udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf, const udx_stream_recv_info_t *info);
 typedef void (*udx_stream_close_cb)(udx_stream_t *stream, int status);
 typedef void (*udx_stream_finalize_cb)(udx_stream_t *stream);
 typedef uint32_t (*udx_stream_get_read_buffer_size_cb)(udx_stream_t *stream);
@@ -265,6 +278,7 @@ struct udx_stream_s {
   udx_stream_firewall_cb on_firewall;
   udx_stream_read_cb on_read;
   udx_stream_recv_cb on_recv;
+  udx_stream_recv_with_info_cb on_recv_with_info;
   udx_stream_drain_cb on_drain;
   udx_stream_close_cb on_close;
   udx_stream_finalize_cb on_finalize;
@@ -647,6 +661,9 @@ udx_stream_firewall (udx_stream_t *stream, udx_stream_firewall_cb firewall_cb);
 
 int
 udx_stream_recv_start (udx_stream_t *stream, udx_stream_recv_cb cb);
+
+int
+udx_stream_recv_start_with_info (udx_stream_t *stream, udx_stream_recv_with_info_cb cb);
 
 int
 udx_stream_recv_stop (udx_stream_t *stream);

--- a/src/udx.c
+++ b/src/udx.c
@@ -1538,13 +1538,24 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
     }
   }
 
-  if (type & UDX_HEADER_MESSAGE) {
-    if (stream->on_recv != NULL) {
-      uv_buf_t b = uv_buf_init(buf, buf_len);
+  if (type & UDX_HEADER_MESSAGE && (stream->status & UDX_STREAM_RECEIVING)) {
+    uv_buf_t b = uv_buf_init(buf, buf_len);
+
+    if (stream->on_recv_with_info != NULL) {
+      udx_stream_recv_info_t info = {
+        .socket = socket,
+        .from = addr,
+        .source = stream->socket == socket ? UDX_STREAM_RECV_SOURCE_CURRENT : UDX_STREAM_RECV_SOURCE_OTHER
+      };
+
+      stream->on_recv_with_info(stream, buf_len, &b, &info);
+    } else {
+      assert(stream->on_recv != NULL);
       stream->on_recv(stream, buf_len, &b);
-      if (stream->status & UDX_STREAM_DEAD) {
-        return 1;
-      }
+    }
+
+    if (stream->status & UDX_STREAM_DEAD) {
+      return 1;
     }
   }
 
@@ -2347,6 +2358,18 @@ udx_stream_recv_start (udx_stream_t *stream, udx_stream_recv_cb cb) {
   if (stream->status & UDX_STREAM_RECEIVING) return UV_EALREADY;
 
   stream->on_recv = cb;
+  stream->on_recv_with_info = NULL;
+  stream->status |= UDX_STREAM_RECEIVING;
+
+  return 0;
+}
+
+int
+udx_stream_recv_start_with_info (udx_stream_t *stream, udx_stream_recv_with_info_cb cb) {
+  if (stream->status & UDX_STREAM_RECEIVING) return UV_EALREADY;
+
+  stream->on_recv = NULL;
+  stream->on_recv_with_info = cb;
   stream->status |= UDX_STREAM_RECEIVING;
 
   return 0;
@@ -2357,6 +2380,7 @@ udx_stream_recv_stop (udx_stream_t *stream) {
   if ((stream->status & UDX_STREAM_RECEIVING) == 0) return 0;
 
   stream->on_recv = NULL;
+  stream->on_recv_with_info = NULL;
   stream->status ^= UDX_STREAM_RECEIVING;
 
   return 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ list(APPEND tests
   stream-relay
   stream-relay-firewall-source
   stream-relay-force-slow-path
+  stream-recv-source
   stream-send-recv
   stream-send-recv-ipv6
   stream-write-read

--- a/test/stream-recv-source.c
+++ b/test/stream-recv-source.c
@@ -1,0 +1,143 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "../include/udx.h"
+
+uv_loop_t loop;
+udx_t udx;
+
+struct sockaddr_in aaddr;
+udx_socket_t asock;
+udx_stream_t astream;
+
+struct sockaddr_in baddr;
+udx_socket_t bsock;
+udx_stream_t bstream;
+
+struct sockaddr_in caddr;
+udx_socket_t csock;
+
+uv_timer_t timeout;
+
+udx_stream_send_t first_req;
+udx_stream_send_t second_req;
+
+bool firewall_called = false;
+int recv_count = 0;
+
+static void
+on_timeout (uv_timer_t *timer) {
+  assert(false && "stream recv source test timed out");
+}
+
+static void
+on_send (udx_stream_send_t *req, int status) {
+  assert(status == 0);
+}
+
+static int
+on_firewall (udx_stream_t *stream, udx_socket_t *socket, const struct sockaddr *from) {
+  assert(stream == &astream);
+  assert(socket == &asock);
+
+  firewall_called = true;
+  return 0;
+}
+
+static void
+on_recv (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf, const udx_stream_recv_info_t *info) {
+  int e;
+
+  if (recv_count == 0) {
+    assert(memcmp(buf->base, "first", 5) == 0);
+    assert(info->socket == &asock);
+    assert(info->source == UDX_STREAM_RECV_SOURCE_CURRENT);
+
+    // Move the receiving stream to another socket while the peer still sends to
+    // the original address. The next accepted packet should be marked as other.
+    e = udx_stream_change_remote(&astream, &csock, 2, (struct sockaddr *) &baddr, NULL);
+    assert(e == 1);
+
+    recv_count++;
+
+    uv_buf_t second = uv_buf_init("second", 6);
+    e = udx_stream_send(&second_req, &bstream, &second, 1, on_send);
+    assert(e == 0);
+
+    return;
+  }
+
+  assert(memcmp(buf->base, "second", 6) == 0);
+  assert(info->socket == &asock);
+  assert(info->source == UDX_STREAM_RECV_SOURCE_OTHER);
+
+  recv_count++;
+
+  uv_timer_stop(&timeout);
+  uv_stop(&loop);
+}
+
+static void
+bind_addr (udx_socket_t *socket, struct sockaddr_in *addr, int port) {
+  int e = uv_ip4_addr("127.0.0.1", port, addr);
+  assert(e == 0);
+
+  e = udx_socket_bind(socket, (struct sockaddr *) addr, 0);
+  assert(e == 0);
+}
+
+int
+main () {
+  int e;
+
+  uv_loop_init(&loop);
+
+  e = udx_init(&loop, &udx, NULL);
+  assert(e == 0);
+
+  e = udx_socket_init(&udx, &asock, NULL);
+  assert(e == 0);
+
+  e = udx_socket_init(&udx, &bsock, NULL);
+  assert(e == 0);
+
+  e = udx_socket_init(&udx, &csock, NULL);
+  assert(e == 0);
+
+  bind_addr(&asock, &aaddr, 18081);
+  bind_addr(&bsock, &baddr, 18082);
+  bind_addr(&csock, &caddr, 18083);
+
+  e = udx_stream_init(&udx, &astream, 1, NULL, NULL);
+  assert(e == 0);
+
+  e = udx_stream_init(&udx, &bstream, 2, NULL, NULL);
+  assert(e == 0);
+
+  e = udx_stream_firewall(&astream, on_firewall);
+  assert(e == 0);
+
+  e = udx_stream_recv_start_with_info(&astream, on_recv);
+  assert(e == 0);
+
+  e = udx_stream_connect(&astream, &asock, 2, (struct sockaddr *) &baddr);
+  assert(e == 0);
+
+  e = udx_stream_connect(&bstream, &bsock, 1, (struct sockaddr *) &aaddr);
+  assert(e == 0);
+
+  uv_timer_init(&loop, &timeout);
+  uv_timer_start(&timeout, on_timeout, 3000, 0);
+
+  uv_buf_t first = uv_buf_init("first", 5);
+  e = udx_stream_send(&first_req, &bstream, &first, 1, on_send);
+  assert(e == 0);
+
+  uv_run(&loop, UV_RUN_DEFAULT);
+
+  assert(firewall_called);
+  assert(recv_count == 2);
+
+  return 0;
+}


### PR DESCRIPTION
Expose message info so message consumers can reason about wether the source is "current" or "previous". During holepunch this would allow users to understand if messages are coming through the direct connection ("current") or are a result of inflight messages ("previous" relay connection)

Co-written with AI