### PR TITLE
Increase forced-drop test timeout

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,6 +64,14 @@ foreach(test IN LISTS tests)
     TIMEOUT 30
   )
 
+  if(${test} STREQUAL stream-write-read-force-drop)
+    set_tests_properties(
+      ${test}
+      PROPERTIES
+      TIMEOUT 60
+    )
+  endif()
+
   if(${test} IN_LIST skipped_tests)
     set_tests_properties(
       ${test}


### PR DESCRIPTION
stream-write-read-force-drop sends 50MB while forcing packet drops, and its runtime is highly variable, and made the CI flake in #295 

I ran it locally 

17s, 23s, 8s, 1s, 10s, 2s, 25s, 8s, 2s, 14s 

and so on Github runners it is dangerously close to the limit. 

Co-written with AI