### PR TITLE
Remove dead code

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -81,9 +81,6 @@ uint32_t
 udx__max_payload (udx_stream_t *stream);
 
 void
-udx__close_handles (udx_socket_t *socket);
-
-void
 udx__rate_pkt_sent (udx_stream_t *stream, udx_packet_t *pkt);
 
 void

--- a/src/udx.c
+++ b/src/udx.c
@@ -1678,8 +1678,6 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
     detect_loss_repaired_by_loss_probe(stream, ack);
   }
 
-  bool is_limited = stream->ca_state == UDX_CA_RECOVERY || stream->ca_state == UDX_CA_LOSS;
-
   if (seq_compare(ack, stream->high_seq) > 0 && (stream->ca_state == UDX_CA_RECOVERY || stream->ca_state == UDX_CA_LOSS)) {
     if (stream->ca_state == UDX_CA_RECOVERY) {
       stream->cwnd = stream->ssthresh;
@@ -1746,10 +1744,6 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
   if (stream->status & UDX_STREAM_DEAD) {
     return 1; /* re-entry check */
   }
-
-  // we are user limited if queued bytes (that includes current inflight + a max packet) is less than the window
-  // we are rwnd limited if rwnd < cwnd
-  if (!is_limited) is_limited = stream->writes_queued_bytes + udx__max_payload(stream) < cwnd_in_bytes(stream) || send_rwnd_in_packets(stream) < stream->cwnd;
 
   delivered = stream->delivered - delivered;
   lost = stream->lost - lost;

--- a/src/udx.c
+++ b/src/udx.c
@@ -1914,11 +1914,6 @@ udx_init (uv_loop_t *loop, udx_t *udx, udx_idle_cb on_idle) {
   return 0;
 }
 
-void
-udx_idle (udx_t *udx, udx_idle_cb cb) {
-  udx->on_idle = cb;
-}
-
 int
 udx_is_idle (udx_t *udx) {
   return udx->refs == 0;


### PR DESCRIPTION
Found some minor dead code and so had AI help find more. It found more than I included here but I didn't remove them items such as `udx__queue_head()` & `udx__is_be()` since they are implementations of their counter parts that are used so serve to make the queue and endian files "complete".