### PR TITLE
Simplify RTO logic - Fix RACK preventing RTO

### DIFF
--- a/include/udx.h
+++ b/include/udx.h
@@ -238,10 +238,11 @@ struct udx_stream_s {
   uint8_t ca_state;
   uint32_t high_seq; // seq at time of congestion, marks end of recovery
   bool hit_high_watermark;
-  uint16_t rto_count;
+  uint8_t rto_count; // stream closed if rto_count > UDX_MAX_RTO_TIMEOUTS, reset when ack is advanced.
   uint16_t zwp_count;
   uint16_t fast_recovery_count;
   uint16_t retransmit_count;
+  uint16_t lifetime_rto_count; // total rto expirations over the lifetime of the stream
   size_t writes_queued_bytes;
 
   uint16_t pkt_capacity;
@@ -417,7 +418,6 @@ struct udx_packet_s {
   bool lost;
   bool retransmitted;
   uint8_t transmits;
-  uint8_t rto_timeouts;
   bool is_mtu_probe;
   uint8_t ref_count; // 2 references - the uv_udp_send_t callback and the on_ack callback.
                      // when 0, packet has been acked and is not in flight. the packet may be free().

--- a/src/udx.c
+++ b/src/udx.c
@@ -1185,6 +1185,7 @@ udx_rto_timeout (uv_timer_t *timer) {
   // exit fast recovery if we are in it
   stream->high_seq = stream->seq;
   stream->rto_count++;
+  stream->lifetime_rto_count++;
   stream->ca_state = UDX_CA_LOSS;
 
   // rack 7.1 TLP_init
@@ -1202,6 +1203,10 @@ udx_rto_timeout (uv_timer_t *timer) {
   uint64_t now = uv_now(timer->loop);
   uint32_t rack_reo_wnd = rack_update_reo_wnd(stream);
 
+  if (stream->rto_count >= UDX_MAX_RTO_TIMEOUTS) {
+    close_stream(stream, UV_ETIMEDOUT);
+    return;
+  }
   // rack 6.3
 
   for (uint32_t seq = stream->remote_acked; seq != stream->seq; seq++) {
@@ -1216,13 +1221,7 @@ udx_rto_timeout (uv_timer_t *timer) {
     int64_t remaining = pkt->time_sent + stream->rack_rtt + rack_reo_wnd - now;
 
     if (pkt->seq == stream->remote_acked || remaining < 0) {
-      if (pkt->rto_timeouts >= UDX_MAX_RTO_TIMEOUTS) {
-        close_stream(stream, UV_ETIMEDOUT);
-        return;
-      }
-
       stream->lost++;
-      pkt->rto_timeouts++;
 
       if (pkt->is_mtu_probe) {
         mtu_unprobeify_packet(pkt, stream);
@@ -1681,6 +1680,7 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
 
   if (ack_advanced) {
     stream->remote_acked = ack;
+    stream->rto_count = 0;
   }
 
   if (ended) { // remote acked our end

--- a/test/stream-rto.c
+++ b/test/stream-rto.c
@@ -69,7 +69,7 @@ main () {
   assert(e);
   // hack to make the packet timeout after 1 RTO, obv. relies
   // on many internal details that are likely to change
-  stream.pkt->rto_timeouts = 6;
+  stream.rto_count = 6;
 
   e = uv_run(&loop, UV_RUN_DEFAULT);
   assert(e == 0);


### PR DESCRIPTION
This simplifies the stream RTO logic.

1. on RTO timer expiration, increment `stream->rto_count`, and if it is greater than `UDX_MAX_RTO_TIMEOUTS`, close the stream.
2. when a packet advances stream->remote_acked, reset `stream->rto_count = 0`.

This solves a bug where a packet being marked lost by RACK would be skipped for checking during RTO timeout as it is already marked "lost" - but then, it would also skip the check to timeout the stream.

Note: This PR changes the meaning of `stream->rto_count`, but it adds `stream->lifetime_rto_count` to replace it.