### PR TITLE
remove ssthresh

### DIFF
--- a/examples/udxperf.c
+++ b/examples/udxperf.c
@@ -276,7 +276,7 @@ print_interval (udxperf_client_t *client, uint64_t bytes, uint64_t start, uint64
 
   printf("[%3d] %6.4f-%6.4f sec %s %s/sec", stream->local_id, (start - client->start_time) / 1000.0, (end - client->start_time) / 1000.0, bytes_buf, bps_buf);
   if (is_client && extra_wanted) {
-    printf(" cwnd=%d ssthresh=%d pacing_rate=%u fast_recovery_count=%d rto_count=%d rtx_count=%d", stream->cwnd, stream->pacing_bytes_per_ms, stream->ssthresh, stream->fast_recovery_count, stream->rto_count, stream->retransmit_count);
+    printf(" cwnd=%d pacing_rate=%u fast_recovery_count=%d rto_count=%d rtx_count=%d", stream->cwnd, stream->pacing_bytes_per_ms, stream->fast_recovery_count, stream->rto_count, stream->retransmit_count);
   }
 
   uint64_t bw;

--- a/include/udx.h
+++ b/include/udx.h
@@ -379,7 +379,6 @@ struct udx_stream_s {
 
   uint32_t sacks;
   uint32_t cwnd;          // packets
-  uint32_t ssthresh;      // packets
   uint32_t send_rwnd;     // remote advertised rwnd
   uint32_t recv_rwnd_max; // default: UDX_DEFAULT_RWND_MAX
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -98,6 +98,9 @@ void
 bbr_init (udx_stream_t *stream);
 
 void
+bbr_save_cwnd (udx_stream_t *stream);
+
+void
 bbr_on_rto (udx_stream_t *stream);
 
 void

--- a/src/udx.c
+++ b/src/udx.c
@@ -664,6 +664,7 @@ send_ack (udx_stream_t *stream) {
 
 static bool
 stream_may_send (udx_stream_t *stream, bool retransmit) {
+  assert(stream->cwnd > 0);
   update_pacing_time(stream);
   if (stream->tb_available == 0) {
     return false;

--- a/src/udx.c
+++ b/src/udx.c
@@ -1125,6 +1125,7 @@ rack_detect_loss (udx_stream_t *stream) {
 
     // recover until the full window is acked
     stream->ca_state = UDX_CA_RECOVERY;
+    bbr_save_cwnd(stream);
     stream->high_seq = stream->seq;
     // rack 7.1 TLP_init
     stream->tlp_in_flight = false;

--- a/src/udx.c
+++ b/src/udx.c
@@ -1185,6 +1185,13 @@ udx_rto_timeout (uv_timer_t *timer) {
   assert(stream->status & UDX_STREAM_CONNECTED);
   assert(stream->remote_acked != stream->seq);
 
+  // save bbr->prior_cwnd before entering loss so that it can be restored after exiting loss.
+  // internally bbr_save_cwnd will only lower the saved cwnd if it has not already been lowered
+  // by previous loss or being in the PROBE_RTT phase.
+  // bbr_save_cwnd() _may_ increase the saved cwnd if the current cwnd is higher, in
+  // this case the higher cwnd is justified by delivered packets.
+  bbr_save_cwnd(stream);
+
   // exit fast recovery if we are in it
   stream->high_seq = stream->seq;
   stream->rto_count++;
@@ -1240,6 +1247,8 @@ udx_rto_timeout (uv_timer_t *timer) {
       stream->inflight -= pkt->size;
     }
   }
+
+  stream->cwnd = stream->inflight_queue.len + 1;
 
   bbr_on_rto(stream);
   send_packets(stream);
@@ -1663,9 +1672,6 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
   }
 
   if (seq_compare(ack, stream->high_seq) > 0 && (stream->ca_state == UDX_CA_RECOVERY || stream->ca_state == UDX_CA_LOSS)) {
-    if (stream->ca_state == UDX_CA_RECOVERY) {
-      stream->cwnd = stream->ssthresh;
-    }
     stream->ca_state = UDX_CA_OPEN;
   }
 
@@ -2332,7 +2338,6 @@ udx_stream_init (udx_t *udx, udx_stream_t *stream, uint32_t local_id, udx_stream
   udx__queue_init(&stream->retransmit_queue);
   udx__queue_init(&stream->write_queue);
 
-  stream->ssthresh = 0xffff;
   stream->cwnd = 10;
   stream->recv_rwnd_max = UDX_DEFAULT_RWND_MAX;
   stream->send_rwnd = UDX_DEFAULT_RWND_MAX;

--- a/src/udx_bbr.c
+++ b/src/udx_bbr.c
@@ -243,6 +243,7 @@ bbr_set_cwnd (udx_stream_t *stream, udx_rate_sample_t *rs, uint32_t acked, doubl
   cwnd = max_uint32(cwnd, bbr_cwnd_min_target);
 done:
   stream->cwnd = cwnd;
+  assert(stream->cwnd > 0);
   if (stream->bbr.state == UDX_BBR_STATE_PROBE_RTT) {
     stream->cwnd = min_uint32(stream->cwnd, bbr_cwnd_min_target);
   }

--- a/src/udx_bbr.c
+++ b/src/udx_bbr.c
@@ -117,7 +117,7 @@ bbr_set_pacing_rate (udx_stream_t *stream, double bw, double gain) {
   }
 }
 
-static void
+void
 bbr_save_cwnd (udx_stream_t *stream) {
   // save last known cwnd when entering recovery, we use it to restore
   // after completing recovery successfully
@@ -149,7 +149,7 @@ bbr_on_transmit_start (udx_stream_t *stream, uint64_t now_ms) {
 
 // calculate bdp based on min RTT and the estimated bottleneck bandwidth
 // bdp = bw * min_rtt * gain, unit is bytes
-// note: bw is in packets!
+// note: bdp is in packets!
 
 static uint32_t
 bbr_bdp (udx_stream_t *stream, double bw, double gain) {
@@ -158,7 +158,7 @@ bbr_bdp (udx_stream_t *stream, double bw, double gain) {
     return 10; // cap at initial cwnd
   }
 
-  return bw * stream->bbr.min_rtt_ms * gain;
+  return max_uint32(bw * stream->bbr.min_rtt_ms * gain, 1);
 }
 
 static uint32_t
@@ -424,8 +424,7 @@ bbr_check_drain (udx_stream_t *stream, udx_rate_sample_t *rs) {
 
     debug_throughput_printf(stream, "drain");
     stream->bbr.state = UDX_BBR_STATE_DRAIN; // drain hypothetical bottleneck queue
-    stream->ssthresh = bbr_inflight(stream, bbr_max_bw(stream), 1.0);
-    // debug_printf("bbr: rid=%u entering DRAIN cwnd=%u ssthresh=%u bbr_max_bw=%f time=%lu\n", stream->remote_id, stream->cwnd, stream->ssthresh, bbr_max_bw(stream), uv_now(stream->udx->loop));
+    // debug_printf("bbr: rid=%u entering DRAIN cwnd=%u bbr_max_bw=%f time=%lu\n", stream->remote_id, stream->cwnd, bbr_max_bw(stream), uv_now(stream->udx->loop));
   }
 
   if (stream->bbr.state == UDX_BBR_STATE_DRAIN && stream->inflight_queue.len <= bbr_inflight(stream, bbr_max_bw(stream), 1.0)) {
@@ -556,7 +555,6 @@ bbr_main (udx_stream_t *stream, udx_rate_sample_t *rs) {
 void
 bbr_init (udx_stream_t *stream) {
   stream->bbr.prior_cwnd = 0;
-  stream->ssthresh = 0xffff;
   stream->bbr.rtt_count = 0;
   stream->bbr.next_rtt_delivered = stream->delivered;
   stream->bbr.prev_ca_state = UDX_CA_OPEN;
@@ -587,21 +585,6 @@ bbr_init (udx_stream_t *stream) {
   stream->bbr.extra_acked_win_index = 0;
   stream->bbr.extra_acked[0] = 0;
   stream->bbr.extra_acked[1] = 0;
-}
-
-// Linux additionally adds these hooks which we may consider in the future
-// bbr_sndbuf_expand(socket)
-//   - unlikely to need, we limit ourselves only with cwnd and rwnd, but don't have a memory limit
-//     (besides of course the kernels send buffer)
-// bbr_undo_cwnd(socket)
-//   - used for cwnd reduction undo e.g. with DSACK
-// bbr_ssthresh(socket)
-//   - called when entering loss recovery, used to save cwnd for recovery
-
-uint32_t
-bbr_ssthresh (udx_stream_t *stream) {
-  bbr_save_cwnd(stream);
-  return stream->ssthresh;
 }
 
 int


### PR DESCRIPTION
- removes ssthresh, which is unnecessary for BBR congestion control
- this fixes a bug where we would 'restore' cwnd from ssthresh after leaving RECOVERY or LOSS, and ssthresh could become 0.
- call bbr_save_cwnd() on RTO and set cwnd to inflight+1
- clamp bbr_bdp() to a minimum of one packet. Not strictly necessary since we clamp cwnd to a minimum but a zero bdp doesn't make sense.